### PR TITLE
fix: [sort] func passed to Doc:replace must have two return values

### DIFF
--- a/plugins/sort.lua
+++ b/plugins/sort.lua
@@ -24,7 +24,7 @@ command.add("core.docview", {
       local head, body, foot = text:match("(\n*)(.-)(\n*)$")
       local lines = split_lines(body)
       table.sort(lines, function(a, b) return a:lower() < b:lower() end)
-      return head .. table.concat(lines, "\n") .. foot
+      return head .. table.concat(lines, "\n") .. foot, 1
     end)
   end,
 })


### PR DESCRIPTION
Caused error `/usr/share/lite-xl/core/doc/init.lua:443: attempt to perform arithmetic on a nil value at /usr/share/lite-xl/core/init.lua:1114` when using `sort:sort`.