### PR TITLE
indentguide: use indent size from doc instead of config

### DIFF
--- a/plugins/indentguide.lua
+++ b/plugins/indentguide.lua
@@ -5,6 +5,7 @@ local DocView = require "core.docview"
 
 
 local function get_line_spaces(doc, idx, dir)
+  local _, indent_size = doc:get_indent_info()
   local text = doc.lines[idx]
   if not text then
     return 0
@@ -15,7 +16,7 @@ local function get_line_spaces(doc, idx, dir)
   end
   local n = 0
   for i = s, e do
-    n = n + (text:byte(i) == 9 and config.indent_size or 1)
+    n = n + (text:byte(i) == 9 and indent_size or 1)
   end
   return n
 end
@@ -35,16 +36,17 @@ local draw_line_text = DocView.draw_line_text
 
 function DocView:draw_line_text(idx, x, y)
   local spaces = get_line_indent_guide_spaces(self.doc, idx)
+  local _, indent_size = self.doc:get_indent_info()
   local w = math.ceil(1 * SCALE)
   local h = self:get_line_height()
   local sspaces = ""
   local font = self:get_font()
   local ss = font:subpixel_scale()
-  for _ = 0, spaces - 1, config.indent_size do
+  for _ = 0, spaces - 1, indent_size do
     local color = style.guide or style.selection
     local sw = font:get_width_subpixel(sspaces) / ss
     renderer.draw_rect(x + sw, y, w, h, color)
-    sspaces = sspaces .. (' '):rep(config.indent_size)
+    sspaces = sspaces .. (' '):rep(indent_size)
   end
   draw_line_text(self, idx, x, y)
 end


### PR DESCRIPTION
personally i prefer using size 4 tabs for indentation, but the lite xl codebase and plugins use 2 spaces which can cause it to not be aligned properly