### PR TITLE
Add more `bracketmatch` styles

### DIFF
--- a/plugins/bracketmatch.lua
+++ b/plugins/bracketmatch.lua
@@ -10,11 +10,13 @@ local config = require "core.config"
 --   underline color  = `style.bracketmatch_color`
 --   bracket color    = `style.bracketmatch_char_color`
 --   background color = `style.bracketmatch_block_color`
+--   frame color      = `style.bracketmatch_frame_color`
 
 config.plugins.bracketmatch = {
   highligh_both = true, -- highlight the current bracket too
-  style = "underline",  -- can be "underline", "block", "none"
+  style = "underline",  -- can be "underline", "block", "frame", "none"
   color_char = false,   -- color the bracket
+  line_size = math.ceil(1 * SCALE), -- the size of the lines used in "underline" and "frame"
 }
 
 
@@ -148,6 +150,9 @@ local function draw_decoration(dv, x, y, line, col)
   local char_color = style.bracketmatch_char_color
                      or (conf.style == "block" and style.background or style.syntax["keyword"])
   local block_color = style.bracketmatch_block_color or style.line_number2
+  local frame_color = style.bracketmatch_frame_color or style.line_number2
+
+  local h = conf.line_size
 
   if conf.color_char or conf.style == "block" then
     redraw_char(dv, x, y, line, col,
@@ -156,10 +161,18 @@ local function draw_decoration(dv, x, y, line, col)
   if conf.style == "underline" then
     local x1 = x + dv:get_col_x_offset(line, col)
     local x2 = x + dv:get_col_x_offset(line, col + 1)
-    local h = math.ceil(1 * SCALE)
     local lh = dv:get_line_height()
 
     renderer.draw_rect(x1, y + lh - h, x2 - x1, h, color)
+  elseif conf.style == "frame" then
+    local x1 = x + dv:get_col_x_offset(line, col)
+    local x2 = x + dv:get_col_x_offset(line, col + 1)
+    local lh = dv:get_line_height()
+
+    renderer.draw_rect(x1, y + lh - h, x2 - x1, h, frame_color)
+    renderer.draw_rect(x1, y, x2 - x1, h, frame_color)
+    renderer.draw_rect(x1, y, h, lh, frame_color)
+    renderer.draw_rect(x2, y, h, lh, frame_color)
   end
 end
 


### PR DESCRIPTION
Now `bracketmatch` ignores brackets found in comments and has a few different styles.

```lua
-- Colors can be configured as follows:
--   underline color  = `style.bracketmatch_color`
--   bracket color    = `style.bracketmatch_char_color`
--   background color = `style.bracketmatch_block_color`
--   frame color      = `style.bracketmatch_frame_color`

config.plugins.bracketmatch = {
  highligh_both = true, -- highlight the current bracket too
  style = "underline",  -- can be "underline", "block", "frame", "none"
  color_char = false,   -- color the bracket
  line_size = math.ceil(1 * SCALE), -- the size of the lines used in "underline" and "frame"
}
```
Underline
![Screenshot from 2022-04-30 04-35-01](https://user-images.githubusercontent.com/2798487/166087144-dc3f5c6f-ee6a-4397-bcef-98ae33921679.png)
Underline + color_char
![Screenshot from 2022-04-30 04-35-08](https://user-images.githubusercontent.com/2798487/166087145-c6944440-e059-481e-9d70-de6fac1f63b5.png)
Block
![Screenshot from 2022-04-30 04-35-23](https://user-images.githubusercontent.com/2798487/166087146-6d8eb008-7865-4e84-9830-d85872520660.png)
Block + color_char
![Screenshot from 2022-04-30 04-35-30](https://user-images.githubusercontent.com/2798487/166087147-0c6e161d-adf2-4e0a-8df4-e6c12f4383c8.png)
Frame
![Screenshot from 2022-04-30 04-35-40](https://user-images.githubusercontent.com/2798487/166087148-a4cea67c-3a6f-4dda-baff-5d86a9cd151f.png)
Frame + color_char
![Screenshot from 2022-04-30 04-35-48](https://user-images.githubusercontent.com/2798487/166087150-e99ea7bf-fbd7-47df-9e3b-806523da2a23.png)
None + color_char
![Screenshot from 2022-04-30 04-35-55](https://user-images.githubusercontent.com/2798487/166087152-f62bdb48-4dd7-4b29-98fd-599a2f9a3f5b.png)


Closes #73 and #74.