### PR TITLE
`minimap`: Performance improvements

### DIFF
--- a/plugins/minimap.lua
+++ b/plugins/minimap.lua
@@ -198,8 +198,12 @@ local function show_minimap(docview)
   if not docview:is(DocView) then return false end
   if
     not config.plugins.minimap.enabled
-    or not docview:is(DocView)
-    or per_docview[docview] == false
+    and per_docview[docview] ~= true
+  then
+    return false
+  elseif
+    config.plugins.minimap.enabled
+    and per_docview[docview] == false
   then
     return false
   end
@@ -535,6 +539,7 @@ end
 command.add(nil, {
   ["minimap:toggle-visibility"] = function()
     config.plugins.minimap.enabled = not config.plugins.minimap.enabled
+    setmetatable({}, { __mode = "k" })
   end,
   ["minimap:toggle-syntax-highlighting"] = function()
     config.plugins.minimap.syntax_highlight = not config.plugins.minimap.syntax_highlight
@@ -543,7 +548,11 @@ command.add(nil, {
 
 command.add("core.docview!", {
   ["minimap:toggle-visibility-for-current-view"] = function()
-    per_docview[core.active_view] = per_docview[core.active_view] == false
+    if config.plugins.minimap.enabled then
+      per_docview[core.active_view] = per_docview[core.active_view] == false
+    else
+      per_docview[core.active_view] = not per_docview[core.active_view]
+    end
   end
 })
 


### PR DESCRIPTION
With this PR:
* Rects position and color is cached.
* Touching rects with the same color are merged to avoid doing useless `draw_rect` calls.
* The `spaces_to_split` option is used to specify the minimum amount of spaces needed to split a token.
  This is 2 by default; use 1 to go back to previous behavior.
* Toggling the minimap works even if it's globally disabled.

The main disadvantage of the caching is that invalidation doesn't happen in some cases. For example after changing the color scheme.

Doing some tests I get an improvement of ~30% on the CPU usage while scrolling and a reduction of ~1000 `draw_rect` calls.