### PR TITLE
Add support for SQL strings to language_php

### DIFF
--- a/plugins/language_php.lua
+++ b/plugins/language_php.lua
@@ -10,6 +10,15 @@ local syntax = require "core.syntax"
 require "plugins.language_css"
 require "plugins.language_js"
 
+-- generate SQL string marker regex
+local sql_markers = { 'create', 'select', 'insert', 'update', 'replace', 'delete', 'drop', 'alter' }
+local sql_regex   = {}
+for _,marker in ipairs(sql_markers) do
+    table.insert(sql_regex, marker)
+    table.insert(sql_regex, string.upper(marker))
+end
+sql_regex = table.concat(sql_regex, '|')
+
 -- define the core php syntax coloring
 syntax.add {
   name = "PHP Source",
@@ -26,84 +35,14 @@ syntax.add {
     { pattern = { "/%*", "%*/" },            type = "comment"  },
     -- SQL strings
     {
-        pattern = { '"[cC][rR][eE][aA][tT][eE]%s+', '"', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
+        regex  = { '"(?=(?:'..sql_regex..')\\s+)', '"', '\\' },
+        syntax = '.sql',
+        type   = "string"
     },
     {
-        pattern = { '\'[cC][rR][eE][aA][tT][eE]%s+', '\'', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '"[sS][eE][lL][eE][cC][tT]%s+', '"', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '\'[sS][eE][lL][eE][cC][tT]%s+', '\'', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '"[iI][nN][sS][eE][rR][tT]%s+', '"', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '\'[iI][nN][sS][eE][rR][tT]%s+', '\'', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '"[uU][pP][dD][aA][tT][eE]%s+', '"', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '\'[uU][pP][dD][aA][tT][eE]%s+', '\'', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '"[rR][eE][pP][lL][aA][cC][eE]%s+', '"', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '\'[rR][eE][pP][lL][aA][cC][eE]%s+', '\'', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '"[dD][eE][lL][eE][tT][eE]%s+', '"', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '\'[dD][eE][lL][eE][tT][eE]%s+', '\'', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '"[dD][rR][oO][pP]%s+', '"', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '\'[dD][rR][oO][pP]%s+', '\'', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '"[aA][lL][tT][eE][rR]%s+', '"', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
-    },
-    {
-        pattern = { '\'[aA][lL][tT][eE][rR]%s+', '\'', '\\' },
-        syntax  = '.sql',
-        type    = "keyword"
+        regex  = { '\'(?=(?:'..sql_regex..')\\s+)', '\'', '\\' },
+        syntax = '.sql',
+        type   = "string"
     },
     -- The '\\' is for escaping to work on " or '
     { pattern = { '"', '"', '\\' },          type = "string"   },

--- a/plugins/language_php.lua
+++ b/plugins/language_php.lua
@@ -24,6 +24,87 @@ syntax.add {
     { pattern = "//.-\n",                    type = "comment"  },
     { pattern = "#.-\n",                     type = "comment"  },
     { pattern = { "/%*", "%*/" },            type = "comment"  },
+    -- SQL strings
+    {
+        pattern = { '"[cC][rR][eE][aA][tT][eE]%s+', '"', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '\'[cC][rR][eE][aA][tT][eE]%s+', '\'', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '"[sS][eE][lL][eE][cC][tT]%s+', '"', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '\'[sS][eE][lL][eE][cC][tT]%s+', '\'', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '"[iI][nN][sS][eE][rR][tT]%s+', '"', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '\'[iI][nN][sS][eE][rR][tT]%s+', '\'', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '"[uU][pP][dD][aA][tT][eE]%s+', '"', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '\'[uU][pP][dD][aA][tT][eE]%s+', '\'', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '"[rR][eE][pP][lL][aA][cC][eE]%s+', '"', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '\'[rR][eE][pP][lL][aA][cC][eE]%s+', '\'', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '"[dD][eE][lL][eE][tT][eE]%s+', '"', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '\'[dD][eE][lL][eE][tT][eE]%s+', '\'', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '"[dD][rR][oO][pP]%s+', '"', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '\'[dD][rR][oO][pP]%s+', '\'', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '"[aA][lL][tT][eE][rR]%s+', '"', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
+    {
+        pattern = { '\'[aA][lL][tT][eE][rR]%s+', '\'', '\\' },
+        syntax  = '.sql',
+        type    = "keyword"
+    },
     -- The '\\' is for escaping to work on " or '
     { pattern = { '"', '"', '\\' },          type = "string"   },
     { pattern = { "'", "'", '\\' },          type = "string"   },


### PR DESCRIPTION
Naively detects strings starting with `CREATE`, `SELECT`, `INSERT`, `UPDATE`, `REPLACE`, `DELETE`, `DROP`, or `ALTER` (case insensitive), and marks them as a subsyntax for `.sql` files.

Note that this doesn't create a hard dependency on `language_psql` or any other specific SQL highlighting plugin; if no such plugin is present, SQL strings will simply appear un-highlighted instead of as strings.