### PR TITLE
language_v: add syntax support for raw strings

### DIFF
--- a/plugins/language_v.lua
+++ b/plugins/language_v.lua
@@ -12,8 +12,8 @@ syntax.add {
     { pattern = { '"', '"', '\\' },         type = "string"   },
     { pattern = { "'", "'", '\\' },         type = "string"   },
     { pattern = { "`", "`", '\\' },         type = "string"   },
-    { pattern = "r()'.*'",                  type = {"normal", "string"} }, -- raw string single quotes
-    { pattern = "r()\".*\"",                type = {"normal", "string"} }, -- raw string double quotes
+    { pattern = "r()'.*'",                  type = { "normal", "string" } }, -- raw string single quotes
+    { pattern = "r()\".*\"",                type = { "normal", "string" } }, -- raw string double quotes
     { pattern = "0x[%da-fA-F_]+",           type = "number"   },
     { pattern = "0b[01_]+",                 type = "number"   },
     { pattern = "00[01234567_]+",           type = "number"   },

--- a/plugins/language_v.lua
+++ b/plugins/language_v.lua
@@ -12,8 +12,8 @@ syntax.add {
     { pattern = { '"', '"', '\\' },         type = "string"   },
     { pattern = { "'", "'", '\\' },         type = "string"   },
     { pattern = { "`", "`", '\\' },         type = "string"   },
-    { pattern = { "r'", "'" },              type = "string" }, -- raw string single quotes
-    { pattern = { 'r"', '"' },              type = "string" }, -- raw string double quotes
+    { pattern = { "r'", "'" },              type = "string"   }, -- raw string single quotes
+    { pattern = { 'r"', '"' },              type = "string"   }, -- raw string double quotes
     { pattern = "0x[%da-fA-F_]+",           type = "number"   },
     { pattern = "0b[01_]+",                 type = "number"   },
     { pattern = "00[01234567_]+",           type = "number"   },

--- a/plugins/language_v.lua
+++ b/plugins/language_v.lua
@@ -12,6 +12,8 @@ syntax.add {
     { pattern = { '"', '"', '\\' },         type = "string"   },
     { pattern = { "'", "'", '\\' },         type = "string"   },
     { pattern = { "`", "`", '\\' },         type = "string"   },
+    { pattern = "r()'.*'",                  type = {"normal", "string"} }, -- raw string single quotes
+    { pattern = "r()\".*\"",                type = {"normal", "string"} }, -- raw string double quotes
     { pattern = "0x[%da-fA-F_]+",           type = "number"   },
     { pattern = "0b[01_]+",                 type = "number"   },
     { pattern = "00[01234567_]+",           type = "number"   },

--- a/plugins/language_v.lua
+++ b/plugins/language_v.lua
@@ -12,8 +12,8 @@ syntax.add {
     { pattern = { '"', '"', '\\' },         type = "string"   },
     { pattern = { "'", "'", '\\' },         type = "string"   },
     { pattern = { "`", "`", '\\' },         type = "string"   },
-    { pattern = "r()'.*'",                  type = { "normal", "string" } }, -- raw string single quotes
-    { pattern = "r()\".*\"",                type = { "normal", "string" } }, -- raw string double quotes
+    { pattern = { "r'", "'" },              type = "string" }, -- raw string single quotes
+    { pattern = { 'r"', '"' },              type = "string" }, -- raw string double quotes
     { pattern = "0x[%da-fA-F_]+",           type = "number"   },
     { pattern = "0b[01_]+",                 type = "number"   },
     { pattern = "00[01234567_]+",           type = "number"   },


### PR DESCRIPTION
This PR will add raw strings support for the V programming language. (see [V strings](https://github.com/vlang/v/blob/master/doc/docs.md#strings))
Escape characters in a raw string are treated as escaped escape characters. (`\` == `\\` in a raw string)

**before**:
![v_raw_string_no_support](https://user-images.githubusercontent.com/89769190/173245682-66ae1840-85d1-4ca3-8e3c-709e4b2cf478.png)

**after**:
![v_raw_string_support](https://user-images.githubusercontent.com/89769190/173245669-4af290b8-18f5-496e-ad68-eed81a38d880.png)
