### PR TITLE
[nonicons] Fixed wrong icon on opened directory

### DIFF
--- a/plugins/nonicons.lua
+++ b/plugins/nonicons.lua
@@ -121,7 +121,7 @@ function TreeView:get_item_icon(item, active, hovered)
     font = icon_font
     color = style.text
     if item.type == "dir" then
-      icon = item.expanded and "" or "" -- unicode 61771 and 61772
+      icon = item.expanded and "" or "" -- unicode U+F23C and U+F23B
     end
   end
   if config.plugins.nonicons.draw_treeview_icons then


### PR DESCRIPTION
The icon of a opened directory was wrong, the unicode character that was in use don't exists anymore on the new version of nonicons font