### PR TITLE
Add syntax highlighting to JSX tags

### DIFF
--- a/plugins/language_jsx.lua
+++ b/plugins/language_jsx.lua
@@ -15,8 +15,9 @@ syntax.add {
     { pattern = "0x[%da-fA-F]+",        type = "number"   },
     { pattern = "-?%d+[%d%.eE]*",       type = "number"   },
     { pattern = "-?%.?%d+",             type = "number"   },
-    { pattern = "[%+%-=/%*%^%%<>!~|&]", type = "operator" },
+    { pattern = "%f[^<]/?[%a_][%w_]*",  type = "function" },
     { pattern = "[%a_][%w_]*%f[(]",     type = "function" },
+    { pattern = "[%+%-=/%*%^%%<>!~|&]", type = "operator" },
     { pattern = "[%a_][%w_]*",          type = "symbol"   },
   },
   symbols = {

--- a/plugins/language_jsx.lua
+++ b/plugins/language_jsx.lua
@@ -38,6 +38,7 @@ syntax.add {
     ["extends"]    = "keyword",
     ["finally"]    = "keyword",
     ["for"]        = "keyword",
+    ["from"]       = "keyword",
     ["function"]   = "keyword",
     ["get"]        = "keyword",
     ["if"]         = "keyword",


### PR DESCRIPTION
It only adds the highlighting to JSX tags using the function colors

Before:
![JSX file without tags highlighting](https://i.imgur.com/VtwGsNb.png)

After:
![JSX file with tags highlighting](https://imgur.com/JXraYxL.png)