### PR TITLE
Add language plugin for ERB files

### DIFF
--- a/plugins/language_erb.lua
+++ b/plugins/language_erb.lua
@@ -1,0 +1,55 @@
+-- mod-version:3
+local syntax = require "core.syntax"
+
+syntax.add {
+  name = "html-eruby",
+  files = { "%.htm%.erb$", "%.html%.erb$", "%.erb$" },
+  block_comment = { "<!--", "-->" },
+  patterns = {
+    {
+      pattern = {
+        "<%s*[sS][cC][rR][iI][pP][tT]%f[%s>].->",
+        "<%s*/%s*[sS][cC][rR][iI][pP][tT]%s*>"
+      },
+      syntax = ".js",
+      type = "function"
+    },
+    {
+      pattern = {
+        "<%s*[sS][tT][yY][lL][eE]%f[%s>].->",
+        "<%s*/%s*[sS][tT][yY][lL][eE]%s*>"
+      },
+      syntax = ".css",
+      type = "function"
+    },
+    {
+      pattern = {
+        "<%%",
+        "%%>"
+      },
+      syntax = ".rb",
+      type = "function"
+    },
+    {
+      pattern = {
+        "<%%=",
+        "%%>"
+      },
+      syntax = ".rb",
+      type = "function"
+    },
+    { pattern = { "<!%-%-", "%-%->" },     type = "comment"  },
+    { pattern = { '%f[^>][^<]', '%f[<]' }, type = "normal"   },
+    { pattern = { '"', '"', '\\' },        type = "string"   },
+    { pattern = { "'", "'", '\\' },        type = "string"   },
+    { pattern = "0x[%da-fA-F]+",           type = "number"   },
+    { pattern = "-?%d+[%d%.]*f?",          type = "number"   },
+    { pattern = "-?%.?%d+f?",              type = "number"   },
+    { pattern = "%f[^<]![%a_][%w_]*",      type = "keyword2" },
+    { pattern = "%f[^<][%a_][%w_]*",       type = "function" },
+    { pattern = "%f[^<]/[%a_][%w_]*",      type = "function" },
+    { pattern = "[%a_][%w_]*",             type = "keyword"  },
+    { pattern = "[/<>=]",                  type = "operator" },
+  },
+  symbols = {},
+}

--- a/plugins/language_erb.lua
+++ b/plugins/language_erb.lua
@@ -3,7 +3,7 @@ local syntax = require "core.syntax"
 
 syntax.add {
   name = "html-eruby",
-  files = { "%.htm%.erb$", "%.html%.erb$", "%.erb$" },
+  files = { "%.html?%.erb$", "%.erb$" },
   block_comment = { "<!--", "-->" },
   patterns = {
     {


### PR DESCRIPTION
erb files typically has filename.html.erb extension they contain html markup and embedded ruby code this file should properly syntax highlight both html and ruby parts