### PR TITLE
Add workaround for sorted `Doc:get_selection` issue

### DIFF
--- a/plugins/autoinsert.lua
+++ b/plugins/autoinsert.lua
@@ -18,6 +18,18 @@ config.plugins.autoinsert = common.merge({ map = {
 } }, config.plugins.autoinsert)
 
 
+-- Workaround for bug in Lite XL 2.1
+-- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
+local function get_selection(doc, sort)
+  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
+  if line1 then
+    return doc:get_selection_idx(doc.last_selection, sort)
+  else
+    return doc:get_selection_idx(1, sort)
+  end
+end
+
+
 local function is_closer(chr)
   for _, v in pairs(config.plugins.autoinsert.map) do
     if v == chr then
@@ -47,7 +59,7 @@ function DocView:on_text_input(text)
 
   -- wrap selection if we have a selection
   if mapping and self.doc:has_selection() then
-    local l1, c1, l2, c2, swap = self.doc:get_selection(true)
+    local l1, c1, l2, c2, swap = get_selection(self.doc, true)
     self.doc:insert(l2, c2, mapping)
     self.doc:insert(l1, c1, text)
     self.doc:set_selection(l1, c1, l2, c2 + 2, swap)

--- a/plugins/colorpreview.lua
+++ b/plugins/colorpreview.lua
@@ -24,6 +24,18 @@ local black = { common.color "#000000" }
 local tmp = {}
 
 
+-- Workaround for bug in Lite XL 2.1
+-- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
+local function get_selection(doc, sort)
+  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
+  if line1 then
+    return doc:get_selection_idx(doc.last_selection, sort)
+  else
+    return doc:get_selection_idx(1, sort)
+  end
+end
+
+
 local function draw_color_previews(self, line, x, y, ptn, base, nibbles)
   local text = self.doc.lines[line]
   local s, e = 0, 0
@@ -58,7 +70,7 @@ local function draw_color_previews(self, line, x, y, ptn, base, nibbles)
     local text_color = math.max(r, g, b) < 128 and white or black
     tmp[1], tmp[2], tmp[3], tmp[4] = r, g, b, a
 
-    local l1, _, l2, _ = self.doc:get_selection(true)
+    local l1, _, l2, _ = get_selection(self.doc, true)
 
     if not (self.doc:has_selection() and line >= l1 and line <= l2) then
       renderer.draw_rect(x1, y, x2 - x1, self:get_line_height(), tmp)

--- a/plugins/dragdropselected.lua
+++ b/plugins/dragdropselected.lua
@@ -14,6 +14,18 @@ local core = require "core"
 local keymap = require "core.keymap"
 local style = require "core.style"
 
+-- Workaround for bug in Lite XL 2.1
+-- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
+local function get_selection(doc, sort)
+  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
+  if line1 then
+    return doc:get_selection_idx(doc.last_selection, sort)
+  else
+    return doc:get_selection_idx(1, sort)
+  end
+end
+
+
 -- helper function for on_mouse_pressed to determine if mouse down is in selection
 -- iLine is line number where mouse down happened
 -- iCol is column where mouse down happened
@@ -96,7 +108,7 @@ function DocView:on_mouse_pressed(button, x, y, clicks)
   -- convert pixel coordinates to line and column coordinates
   local iLine, iCol = self:resolve_screen_position(x, y)
   -- get selection coordinates
-  local iSelLine1, iSelCol1, iSelLine2, iSelCol2 = self.doc:get_selection(true)
+  local iSelLine1, iSelCol1, iSelLine2, iSelCol2 = get_selection(self.doc, true)
   -- set flag for on_mouse_released and on_mouse_moved() methods to detect dragging
   self.bClickedIntoSelection = isInSelection(iLine, iCol, iSelLine1, iSelCol1,
                                              iSelLine2, iSelCol2)

--- a/plugins/regexreplacepreview.lua
+++ b/plugins/regexreplacepreview.lua
@@ -3,6 +3,18 @@ local core = require "core"
 local keymap = require "core.keymap"
 local command = require "core.command"
 
+-- Workaround for bug in Lite XL 2.1
+-- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
+local function get_selection(doc, sort)
+  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
+  if line1 then
+    return doc:get_selection_idx(doc.last_selection, sort)
+  else
+    return doc:get_selection_idx(1, sort)
+  end
+end
+
+
 -- Takes the following pattern: /pattern/replace/
 -- Capture groupings can be replaced using \1 through \9
 local function regex_replace_file(view, pattern, old_lines, raw, start_line, end_line)
@@ -91,8 +103,8 @@ command.add("core.docview!", {
   ["regex-replace-preview:find-replace-regex"] = function(view)
     local old_lines = {}
     local doc = view.doc
-    local original_selection = { doc:get_selection(true) }
-    local selection = doc:has_selection() and { doc:get_selection(true) } or {}
+    local original_selection = { get_selection(doc, true) }
+    local selection = doc:has_selection() and { get_selection(doc, true) } or {}
     core.command_view:enter("Regex Replace (enter pattern as /old/new/)", {
       text = "/",
       submit = function(pattern)

--- a/plugins/selectionhighlight.lua
+++ b/plugins/selectionhighlight.lua
@@ -4,6 +4,17 @@ local DocView = require "core.docview"
 
 -- originally written by luveti
 
+-- Workaround for bug in Lite XL 2.1
+-- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
+local function get_selection(doc, sort)
+  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
+  if line1 then
+    return doc:get_selection_idx(doc.last_selection, sort)
+  else
+    return doc:get_selection_idx(1, sort)
+  end
+end
+
 local function draw_box(x, y, w, h, color)
   local r = renderer.draw_rect
   local s = math.ceil(SCALE)
@@ -18,7 +29,7 @@ local draw_line_body = DocView.draw_line_body
 
 function DocView:draw_line_body(line, x, y)
   local line_height = draw_line_body(self, line, x, y)
-  local line1, col1, line2, col2 = self.doc:get_selection(true)
+  local line1, col1, line2, col2 = get_selection(self.doc, true)
   if line1 == line2 and col1 ~= col2 then
     local selection = self.doc:get_text(line1, col1, line2, col2)
     if not selection:match("^%s+$") then

--- a/plugins/sort.lua
+++ b/plugins/sort.lua
@@ -3,6 +3,17 @@ local core = require "core"
 local command = require "core.command"
 local translate = require "core.doc.translate"
 
+-- Workaround for bug in Lite XL 2.1
+-- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
+local function get_selection(doc, sort)
+  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
+  if line1 then
+    return doc:get_selection_idx(doc.last_selection, sort)
+  else
+    return doc:get_selection_idx(1, sort)
+  end
+end
+
 local function split_lines(text)
   local res = {}
   for line in (text .. "\n"):gmatch("(.-)\n") do
@@ -15,7 +26,7 @@ command.add("core.docview!", {
   ["sort:sort"] = function(dv)
     local doc = dv.doc
 
-    local l1, c1, l2, c2, swap = doc:get_selection(true)
+    local l1, c1, l2, c2, swap = get_selection(doc, true)
     l1, c1 = translate.start_of_line(doc, l1, c1)
     l2, c2 = translate.end_of_line(doc, l2, c2)
     doc:set_selection(l1, c1, l2, c2, swap)


### PR DESCRIPTION
Until lite-xl/lite-xl@b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release, this workaround is needed to avoid crashes.