### PR TITLE
Extend eval plugin with eval:selected

### DIFF
--- a/plugins/eval.lua
+++ b/plugins/eval.lua
@@ -1,6 +1,8 @@
 -- mod-version:3
 local core = require "core"
 local command = require "core.command"
+local contextmenu = require "plugins.contextmenu"
+local keymap = require "core.keymap"
 
 
 local function eval(str)
@@ -29,4 +31,23 @@ command.add("core.docview", {
       end
     })
   end,
+
+  ["eval:selected"] = function(dv)
+    if dv.doc:has_selection() then
+      local text = dv.doc:get_text(dv.doc:get_selection())
+      dv.doc:text_input(eval(text))
+    else
+      local line = dv.doc:get_selection()
+      local text = dv.doc.lines[line]
+      dv.doc:insert(line+1, 0, "= " .. eval(text) .. "\n")
+    end
+  end,
 })
+
+
+contextmenu:register("core.docview", {
+  { text = "Evaluate Selected",  command = "eval:selected" }
+})
+
+
+keymap.add { ["ctrl+alt+return"] = "eval:selected" }


### PR DESCRIPTION
- if text is selected, replace this text with eval result
- if no text is selected, eval the current line and insert the result in the next line with "= " prefix.

Adding `ctrl+alt+return` default keymap