### PR TITLE
Fix lfautoinsert

### DIFF
--- a/plugins/lfautoinsert.lua
+++ b/plugins/lfautoinsert.lua
@@ -12,7 +12,7 @@ config.plugins.lfautoinsert = common.merge({ map = {
   ["=%s*\n"] = false,
   [":%s*\n"] = false,
   ["->%s*\n"] = false,
-  ["^%s*<([^/][^%s>]*)[^>]*>%s*\n"] = "</$TEXT>",
+  ["^%s*<([^/!][^%s>]*)[^>]*>%s*\n"] = "</$TEXT>",
   ["^%s*{{#([^/][^%s}]*)[^}]*}}%s*\n"] = "{{/$TEXT}}",
   ["/%*%s*\n"] = "*/",
   ["c/c++"] = {


### PR DESCRIPTION
Fix for issue #174

In html files, tags starting with `<!` or `</` should not trigger the plugin to create a closing tag. Other tags should.

Test:
- create empty file called `test.html`
- type: `<!DOCTYPE html>` and press Enter
- verify that the plugin is *not* creating a closing tag
- type `<meta>` and press Enter
- verify that the plugin *is* creating a closing tag `</meta>`
