### PR TITLE
Remove workaround for sorted `Doc:get_selection` issue

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     },
     {
       "description": "Automatically inserts closing brackets and quotes. Also allows selected text to be wrapped with brackets or quotes.",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/autoinsert.lua",
       "id": "autoinsert",
       "mod_version": "3"
@@ -72,7 +72,7 @@
     },
     {
       "description": "Underlays color values (eg. `#ff00ff` or `rgb(255, 0, 255)`) with their resultant color. *([screenshot](https://user-images.githubusercontent.com/3920290/80743752-731bd780-8b15-11ea-97d3-847db927c5dc.png))*",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/colorpreview.lua",
       "id": "colorpreview",
       "mod_version": "3"
@@ -128,7 +128,7 @@
     },
     {
       "description": "Provides basic drag and drop of selected text (in same document)",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/dragdropselected.lua",
       "id": "dragdropselected",
       "mod_version": "3"
@@ -1025,7 +1025,7 @@
     },
     {
       "description": "Allows for you to write a regex and its replacement in one go, and live preview the results.",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/regexreplacepreview.lua",
       "id": "regexreplacepreview",
       "mod_version": "3"
@@ -1053,7 +1053,7 @@
     },
     {
       "description": "Highlights regions of code that match the current selection *([screenshot](https://user-images.githubusercontent.com/3920290/80710883-5f597c80-8ae7-11ea-97f0-76dfacc08439.png))*",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/selectionhighlight.lua",
       "id": "selectionhighlight",
       "mod_version": "3"
@@ -1081,7 +1081,7 @@
     },
     {
       "description": "Sorts selected lines alphabetically",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/sort.lua",
       "id": "sort",
       "mod_version": "3"

--- a/plugins/autoinsert.lua
+++ b/plugins/autoinsert.lua
@@ -18,18 +18,6 @@ config.plugins.autoinsert = common.merge({ map = {
 } }, config.plugins.autoinsert)
 
 
--- Workaround for bug in Lite XL 2.1
--- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
-local function get_selection(doc, sort)
-  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
-  if line1 then
-    return doc:get_selection_idx(doc.last_selection, sort)
-  else
-    return doc:get_selection_idx(1, sort)
-  end
-end
-
-
 local function is_closer(chr)
   for _, v in pairs(config.plugins.autoinsert.map) do
     if v == chr then
@@ -59,7 +47,7 @@ function DocView:on_text_input(text)
 
   -- wrap selection if we have a selection
   if mapping and self.doc:has_selection() then
-    local l1, c1, l2, c2, swap = get_selection(self.doc, true)
+    local l1, c1, l2, c2, swap = self.doc:get_selection(true)
     self.doc:insert(l2, c2, mapping)
     self.doc:insert(l1, c1, text)
     self.doc:set_selection(l1, c1, l2, c2 + 2, swap)

--- a/plugins/colorpreview.lua
+++ b/plugins/colorpreview.lua
@@ -24,18 +24,6 @@ local black = { common.color "#000000" }
 local tmp = {}
 
 
--- Workaround for bug in Lite XL 2.1
--- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
-local function get_selection(doc, sort)
-  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
-  if line1 then
-    return doc:get_selection_idx(doc.last_selection, sort)
-  else
-    return doc:get_selection_idx(1, sort)
-  end
-end
-
-
 local function draw_color_previews(self, line, x, y, ptn, base, nibbles)
   local text = self.doc.lines[line]
   local s, e = 0, 0
@@ -70,7 +58,7 @@ local function draw_color_previews(self, line, x, y, ptn, base, nibbles)
     local text_color = math.max(r, g, b) < 128 and white or black
     tmp[1], tmp[2], tmp[3], tmp[4] = r, g, b, a
 
-    local l1, _, l2, _ = get_selection(self.doc, true)
+    local l1, _, l2, _ = self.doc:get_selection(true)
 
     if not (self.doc:has_selection() and line >= l1 and line <= l2) then
       renderer.draw_rect(x1, y, x2 - x1, self:get_line_height(), tmp)

--- a/plugins/dragdropselected.lua
+++ b/plugins/dragdropselected.lua
@@ -14,18 +14,6 @@ local core = require "core"
 local keymap = require "core.keymap"
 local style = require "core.style"
 
--- Workaround for bug in Lite XL 2.1
--- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
-local function get_selection(doc, sort)
-  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
-  if line1 then
-    return doc:get_selection_idx(doc.last_selection, sort)
-  else
-    return doc:get_selection_idx(1, sort)
-  end
-end
-
-
 -- helper function for on_mouse_pressed to determine if mouse down is in selection
 -- iLine is line number where mouse down happened
 -- iCol is column where mouse down happened
@@ -108,7 +96,7 @@ function DocView:on_mouse_pressed(button, x, y, clicks)
   -- convert pixel coordinates to line and column coordinates
   local iLine, iCol = self:resolve_screen_position(x, y)
   -- get selection coordinates
-  local iSelLine1, iSelCol1, iSelLine2, iSelCol2 = get_selection(self.doc, true)
+  local iSelLine1, iSelCol1, iSelLine2, iSelCol2 = self.doc:get_selection(true)
   -- set flag for on_mouse_released and on_mouse_moved() methods to detect dragging
   self.bClickedIntoSelection = isInSelection(iLine, iCol, iSelLine1, iSelCol1,
                                              iSelLine2, iSelCol2)

--- a/plugins/dragdropselected.lua
+++ b/plugins/dragdropselected.lua
@@ -43,7 +43,7 @@ end -- isInSelection
 
 -- distance between two points
 local function distance(x1, y1, x2, y2)
-  return math.sqrt(math.pow(x2-x1, 2)+math.pow(y2-y1, 2))
+  return math.sqrt((x2-x1)^2+(y2-y1)^2)
 end
 
 local min_drag = style.code_font:get_width(" ")

--- a/plugins/regexreplacepreview.lua
+++ b/plugins/regexreplacepreview.lua
@@ -65,18 +65,6 @@ local function substitute(pattern_string, str, replacement)
   return table.concat(result) .. str:sub(offset), matches, replacements
 end
 
--- Workaround for bug in Lite XL 2.1
--- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
-local function get_selection(doc, sort)
-  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
-  if line1 then
-    return doc:get_selection_idx(doc.last_selection, sort)
-  else
-    return doc:get_selection_idx(1, sort)
-  end
-end
-
-
 -- Takes the following pattern: /pattern/replace/
 -- Capture groupings can be replaced using \1 through \9
 local function regex_replace_file(view, pattern, old_lines, raw, start_line, end_line)
@@ -165,8 +153,8 @@ command.add("core.docview!", {
   ["regex-replace-preview:find-replace-regex"] = function(view)
     local old_lines = {}
     local doc = view.doc
-    local original_selection = { get_selection(doc, true) }
-    local selection = doc:has_selection() and { get_selection(doc, true) } or {}
+    local original_selection = { doc:get_selection(true) }
+    local selection = doc:has_selection() and { doc:get_selection(true) } or {}
     core.command_view:enter("Regex Replace (enter pattern as /old/new/)", {
       text = "/",
       submit = function(pattern)

--- a/plugins/selectionhighlight.lua
+++ b/plugins/selectionhighlight.lua
@@ -4,17 +4,6 @@ local DocView = require "core.docview"
 
 -- originally written by luveti
 
--- Workaround for bug in Lite XL 2.1
--- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
-local function get_selection(doc, sort)
-  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
-  if line1 then
-    return doc:get_selection_idx(doc.last_selection, sort)
-  else
-    return doc:get_selection_idx(1, sort)
-  end
-end
-
 local function draw_box(x, y, w, h, color)
   local r = renderer.draw_rect
   local s = math.ceil(SCALE)
@@ -29,7 +18,7 @@ local draw_line_body = DocView.draw_line_body
 
 function DocView:draw_line_body(line, x, y)
   local line_height = draw_line_body(self, line, x, y)
-  local line1, col1, line2, col2 = get_selection(self.doc, true)
+  local line1, col1, line2, col2 = self.doc:get_selection(true)
   if line1 == line2 and col1 ~= col2 then
     local selection = self.doc:get_text(line1, col1, line2, col2)
     if not selection:match("^%s+$") then

--- a/plugins/sort.lua
+++ b/plugins/sort.lua
@@ -3,17 +3,6 @@ local core = require "core"
 local command = require "core.command"
 local translate = require "core.doc.translate"
 
--- Workaround for bug in Lite XL 2.1
--- Remove this when b029f5993edb7dee5ccd2ba55faac1ec22e24609 is in a release
-local function get_selection(doc, sort)
-  local line1, col1, line2, col2 = doc:get_selection_idx(doc.last_selection)
-  if line1 then
-    return doc:get_selection_idx(doc.last_selection, sort)
-  else
-    return doc:get_selection_idx(1, sort)
-  end
-end
-
 local function split_lines(text)
   local res = {}
   for line in (text .. "\n"):gmatch("(.-)\n") do
@@ -26,7 +15,7 @@ command.add("core.docview!", {
   ["sort:sort"] = function(dv)
     local doc = dv.doc
 
-    local l1, c1, l2, c2, swap = get_selection(doc, true)
+    local l1, c1, l2, c2, swap = doc:get_selection(true)
     l1, c1 = translate.start_of_line(doc, l1, c1)
     l2, c2 = translate.end_of_line(doc, l2, c2)
     doc:set_selection(l1, c1, l2, c2, swap)


### PR DESCRIPTION
As 2.1.1 contains the fix needed, let's remove the workaround.