### PR TITLE
added small qol change to eval.lua

### DIFF
--- a/plugins/eval.lua
+++ b/plugins/eval.lua
@@ -26,7 +26,8 @@ command.add("core.docview", {
     core.command_view:enter("Evaluate And Replace With Result", {
       submit = function(cmd)
         dv.doc:replace(function(str)
-          return eval(cmd)
+          local text = dv.doc:get_text(dv.doc:get_selection())
+          return eval(cmd:gsub("%$", text))
         end)
       end
     })


### PR DESCRIPTION
when using eval:replace, `$` can now be used to get the selected text
this can be used, for example, to chain long formulas

let's say you have `math.sin(math.pi) * 50`
and you wanna evaluate the result of this plus 50
you just `50 + ($)` and it will expand to `50 + (math.sin(math.pi) * 50)` and *that* gets evaluated
not really a gamebreaking change, but it's good for some things