### PR TITLE
Add heredoc sigil and heex file support for Elixir

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -439,7 +439,7 @@
     },
     {
       "description": "Syntax for the [Elixir](https://elixir-lang.org) programming language",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/language_elixir.lua",
       "id": "language_elixir",
       "mod_version": "3"

--- a/plugins/language_elixir.lua
+++ b/plugins/language_elixir.lua
@@ -11,6 +11,7 @@ syntax.add {
     { pattern = { '"""', '"""', '\\' }, type = "string"   },
     { pattern = { '"', '"', '\\' },     type = "string"   },
     { pattern = { "'", "'", '\\' },     type = "string"   },
+    { pattern = { '~%a"""', '"""' },    type = "string"   },
     { pattern = { '~%a[/"|\'%(%[%{<]', '[/"|\'%)%]%}>]', '\\' }, type = "string"},
     { pattern = "-?0x%x+",              type = "number"   },
     { pattern = "-?%d+[%d%.eE]*f?",     type = "number"   },
@@ -74,7 +75,7 @@ syntax.add {
 }
 
 syntax.add {
-  files = { "%.l?eex$" },
+  files = { "%.l?eex$", "%.h?eex$" },
   patterns = {
     { pattern = { "<!%-%-", "%-%->" },     type = "comment"  },
     { pattern = { '%f[^>][^<]', '%f[<]' }, type = "normal"   },


### PR DESCRIPTION
Sigils can use the heredoc triple quote syntax in addition to the single delimiter syntax.

`elixir
@doc ~s"""
This is a heredoc string sigil.
"""`

Also added .heex as a valid extension for HTLM templates in Elixir.