### PR TITLE
carets-a-lot

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -195,7 +195,7 @@
     },
     {
       "description": "Replaces selected Lua code with its evaluated result",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/eval.lua",
       "id": "eval",
       "mod_version": "3"

--- a/manifest.json
+++ b/manifest.json
@@ -101,7 +101,7 @@
     },
     {
       "description": "Customize the caret in the editor",
-      "version": "0.2",
+      "version": "0.3",
       "path": "plugins/custom_caret.lua",
       "id": "custom_caret",
       "mod_version": "3"
@@ -1009,7 +1009,7 @@
     },
     {
       "description": "Adds a motion-trail to the caret *([gif](https://user-images.githubusercontent.com/3920290/83256814-085ccb00-a1ab-11ea-9e35-e6633cbed1a9.gif))*",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/motiontrail.lua",
       "id": "motiontrail",
       "mod_version": "3"
@@ -1192,7 +1192,7 @@
     },
     {
       "description": "Smooth caret animation *([gif](https://user-images.githubusercontent.com/20792268/139006049-a0ba6559-88cb-49a7-8077-4822445b4a1f.gif))*",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/smoothcaret.lua",
       "id": "smoothcaret",
       "mod_version": "3"

--- a/plugins/custom_caret.lua
+++ b/plugins/custom_caret.lua
@@ -2,9 +2,9 @@
 
 --[[
   Author: techie-guy
-
   Plugin to customize the caret in the editor
   Thanks to @Guldoman for the initial example on Discord
+  modifications by @thacuber2a03
 
   Features
     Change the Color and Opacity of the caret
@@ -25,6 +25,7 @@ local style = require "core.style"
 local common = require "core.common"
 local config = require "core.config"
 local DocView = require "core.docview"
+
 
 config.plugins.custom_caret = common.merge({
     shape = "line",
@@ -88,16 +89,28 @@ core.add_thread(function()
   end
 end)
 
+local caret_idx = 1
+
+local docview_update = DocView.update
+function DocView:update()
+  docview_update(self)
+  caret_idx = 1
+end
+
 function DocView:draw_caret(x, y)
   local caret_width = style.caret_width
   local caret_height = self:get_line_height()
   local current_caret_shape = conf.shape
   local caret_color = conf.custom_color and conf.caret_color or style.caret
 
+  local font = self:get_font()
+  local line, col = self.doc:get_selection_idx(caret_idx)
+  local charw = math.ceil(font:get_width(self.doc:get_char(line, col)))
+
   if (current_caret_shape == "block") then
-    caret_width = math.ceil(self:get_font():get_width("a"))
+    caret_width = charw
   elseif (current_caret_shape == "underline") then
-    caret_width = math.ceil(self:get_font():get_width("a"))
+    caret_width = charw
     caret_height = style.caret_width*2
     y = y+self:get_line_height()
   else
@@ -106,4 +119,28 @@ function DocView:draw_caret(x, y)
   end
 
   renderer.draw_rect(x, y, caret_width, caret_height, caret_color)
+  if current_caret_shape == "block" then
+    core.push_clip_rect(x, y, caret_width, caret_height)
+
+    local function draw_char(l, c)
+      l = common.clamp(l, 1, #self.doc.lines   )
+      c = common.clamp(c, 1, #self.doc.lines[l])
+      local cx,cy = self:get_line_screen_position(l, c)
+      renderer.draw_text(
+        font, self.doc:get_char(l, c),
+        cx, cy+self:get_line_text_y_offset(),
+        style.background
+      )
+    end
+
+    for yo=-1, 1 do
+      for xo=-1, 1 do
+        draw_char(line+xo, col+yo)
+      end
+    end
+
+    core.pop_clip_rect(x, y, caret_width, caret_height)
+  end
+
+  caret_idx = caret_idx + 1
 end

--- a/plugins/custom_caret.lua
+++ b/plugins/custom_caret.lua
@@ -150,7 +150,7 @@ function DocView:draw_caret(x, y)
       draw_char(line, col)
     end
 
-    core.pop_clip_rect(x, y, caret_width, caret_height)
+    core.pop_clip_rect()
   end
 
   caret_idx = caret_idx + 1

--- a/plugins/motiontrail.lua
+++ b/plugins/motiontrail.lua
@@ -30,43 +30,69 @@ config.plugins.motiontrail = common.merge({
   }
 }, config.plugins.motiontrail)
 
+local cc_installed = pcall(require, 'plugins.custom_caret')
+local cc_conf = config.plugins.custom_caret
 
 local function lerp(a, b, t)
+  if not (a and b and t) then return 0 end
   return a + (b - a) * t
 end
 
+local caret_index = 1
 
 local function get_caret_rect(dv)
-  local line, col = dv.doc:get_selection()
-  local x, y = dv:get_line_screen_position(line, col)
-  return x, y, style.caret_width, dv:get_line_height()
+  local line, col = dv.doc:get_selection_idx(caret_index)
+  local chw = dv:get_font():get_width(dv.doc:get_char(line, col))
+   local w = style.caret_width
+  local h = dv:get_line_height()
+
+  if cc_installed then
+    local cc_shape = cc_conf.shape
+    if cc_shape ==  "block" then
+      w = chw
+    elseif cc_shape == "underline" then
+      w = chw
+      h = style.caret_width * 2
+    end
+  end
+
+  return w, h
 end
 
+local last_x, last_y, last_view = {}, {}, {}
 
-local last_x, last_y, last_view
+local dv_update = DocView.update
+function DocView:update()
+  caret_index = 1
+  dv_update(self)
+end
 
-local draw = DocView.draw
-
-function DocView:draw(...)
-  draw(self, ...)
+local dv_draw_caret = DocView.draw_caret
+function DocView:draw_caret(x,y)
   if not config.plugins.motiontrail.enabled or self ~= core.active_view then
+    dv_draw_caret(self, x, y)
     return
   end
 
-  local x, y, w, h = get_caret_rect(self)
+  local lsw, lsx, lsy = last_view[caret_index], last_x[caret_index], last_y[caret_index]
+  local w, h = get_caret_rect(self)
 
-  if last_view == self and (x ~= last_x or y ~= last_y) then
+  if lsw == self and (x ~= lsx or y ~= lsy) then
     local lx = x
     for i = 0, 1, 1 / config.plugins.motiontrail.steps do
-      local ix = lerp(x, last_x, i)
-      local iy = lerp(y, last_y, i)
+      local ix = lerp(x, lsx, i)
+      local iy = lerp(y, lsy, i)
+      if cc_conf.shape == "underline" then iy = iy + self:get_line_height() end
       local iw = math.max(w, math.ceil(math.abs(ix - lx)))
-      renderer.draw_rect(ix, iy, iw, h, style.caret)
+      renderer.draw_rect(ix, iy, iw, h, (cc_conf and cc_conf.custom_color) and cc_conf.caret_color or style.caret_color)
       lx = ix
     end
     core.redraw = true
   end
 
-  last_view, last_x, last_y = self, x, y
-end
+  last_view[caret_index], last_x[caret_index], last_y[caret_index] = self, x, y
 
+  caret_index = caret_index + 1
+
+  dv_draw_caret(self, x,y)
+end

--- a/plugins/motiontrail.lua
+++ b/plugins/motiontrail.lua
@@ -84,7 +84,7 @@ function DocView:draw_caret(x,y)
       local iy = lerp(y, lsy, i)
       if cc_conf.shape == "underline" then iy = iy + self:get_line_height() end
       local iw = math.max(w, math.ceil(math.abs(ix - lx)))
-      renderer.draw_rect(ix, iy, iw, h, (cc_conf and cc_conf.custom_color) and cc_conf.caret_color or style.caret_color)
+      renderer.draw_rect(ix, iy, iw, h, (cc_conf and cc_conf.custom_color) and cc_conf.caret_color or style.caret)
       lx = ix
     end
     core.redraw = true

--- a/plugins/motiontrail.lua
+++ b/plugins/motiontrail.lua
@@ -5,6 +5,8 @@ local common = require "core.common"
 local style = require "core.style"
 local DocView = require "core.docview"
 
+local world = 1
+
 config.plugins.motiontrail = common.merge({
   enabled = true,
   steps = 50,
@@ -33,66 +35,98 @@ config.plugins.motiontrail = common.merge({
 local cc_installed = pcall(require, 'plugins.custom_caret')
 local cc_conf = config.plugins.custom_caret
 
-local function lerp(a, b, t)
-  if not (a and b and t) then return 0 end
-  return a + (b - a) * t
-end
-
-local caret_index = 1
-
-local function get_caret_rect(dv)
-  local line, col = dv.doc:get_selection_idx(caret_index)
+local function get_caret_size(dv, i)
+  local line, col = dv.doc:get_selection_idx(i)
   local chw = dv:get_font():get_width(dv.doc:get_char(line, col))
-   local w = style.caret_width
+  local w = style.caret_width
   local h = dv:get_line_height()
 
   if cc_installed then
     local cc_shape = cc_conf.shape
-    if cc_shape ==  "block" then
-      w = chw
-    elseif cc_shape == "underline" then
+    if cc_shape == "underline" or dv.doc.overwrite then
       w = chw
       h = style.caret_width * 2
+    elseif cc_shape ==  "block" then
+      w = chw
     end
   end
 
   return w, h
 end
 
-local last_x, last_y, last_view = {}, {}, {}
+local caret_idx, caret_amt = 1, 0
 
 local dv_update = DocView.update
 function DocView:update()
-  caret_index = 1
+  -- that's a lotta lasts
+  self.last_pos = self.last_pos or {}
+  self.last_view = self.last_view or {}
+  self.last_doc_pos = self.last_doc_pos or {}
+  caret_idx = caret_idx or 1
+
+  -- continue from whatever caret_idx left
+  caret_amt = caret_amt and math.max(caret_amt, caret_idx) or 0
+  for i=1, caret_amt - caret_idx do
+    local ri = caret_idx + i
+    self.last_pos[ri] = nil
+    self.last_view[ri] = nil
+    self.last_doc_pos[ri] = nil
+  end
+  caret_idx = 1
   dv_update(self)
 end
 
+local dv_draw = DocView.draw
+function DocView:draw()
+  self.draws = self.draws and self.draws + 1 or 1
+  return dv_draw(self)
+end
+
 local dv_draw_caret = DocView.draw_caret
-function DocView:draw_caret(x,y)
+function DocView:draw_caret(x, y)
   if not config.plugins.motiontrail.enabled or self ~= core.active_view then
     dv_draw_caret(self, x, y)
     return
   end
 
-  local lsw, lsx, lsy = last_view[caret_index], last_x[caret_index], last_y[caret_index]
-  local w, h = get_caret_rect(self)
+  self.last_pos[caret_idx] = self.last_pos[caret_idx] or {}
+  self.last_doc_pos[caret_idx] = self.last_doc_pos[caret_idx] or {}
+  local line, col = self.doc:get_selection_idx(caret_idx)
 
-  if lsw == self and (x ~= lsx or y ~= lsy) then
-    local lx = x
-    for i = 0, 1, 1 / config.plugins.motiontrail.steps do
-      local ix = lerp(x, lsx, i)
-      local iy = lerp(y, lsy, i)
-      if cc_conf.shape == "underline" then iy = iy + self:get_line_height() end
-      local iw = math.max(w, math.ceil(math.abs(ix - lx)))
-      renderer.draw_rect(ix, iy, iw, h, (cc_conf and cc_conf.custom_color) and cc_conf.caret_color or style.caret)
-      lx = ix
+  if self.draws <= 1 then
+    local lsx, lsy = self.last_pos[caret_idx][1] or x, self.last_pos[caret_idx][2] or y
+    local lsl, lsc = self.last_doc_pos[caret_idx][1], self.last_doc_pos[caret_idx][2]
+    local w, h = get_caret_size(self, caret_idx)
+
+    if self.difference_in_coords and lsx == x and lsy == y then
+      self.difference_in_coords = false
     end
-    core.redraw = true
+
+    if lsl ~= line or lsc ~= col then self.difference_in_coords = true end
+
+    if self.difference_in_coords and self.last_view[caret_idx] == self then
+      local lx = x
+      for i = 0, 1, 1 / config.plugins.motiontrail.steps do
+        local ix = common.lerp(x, lsx, i)
+        local iy = common.lerp(y, lsy, i)
+        if cc_installed and cc_conf.shape == "underline" or self.doc.overwrite then
+          iy = iy + self:get_line_height()
+        end
+        local iw = math.max(w, math.ceil(math.abs(ix - lx)))
+        local color = style.caret
+        if cc_installed and cc_conf.custom_color then
+          color = cc_conf.caret_color
+        end
+        renderer.draw_rect(ix, iy, iw, h, color)
+        lx = ix
+      end
+      core.redraw = true
+    end
   end
 
-  last_view[caret_index], last_x[caret_index], last_y[caret_index] = self, x, y
-
-  caret_index = caret_index + 1
-
-  dv_draw_caret(self, x,y)
+  self.last_pos[caret_idx][1], self.last_pos[caret_idx][2], self.last_view[caret_idx] = x, y, self
+  self.last_doc_pos[caret_idx][1], self.last_doc_pos[caret_idx][2] = line, col
+  caret_idx = caret_idx + 1
+  self.draws = 0
+  dv_draw_caret(self, x, y)
 end

--- a/plugins/smoothcaret.lua
+++ b/plugins/smoothcaret.lua
@@ -31,6 +31,8 @@ config.plugins.smoothcaret = common.merge({
   }
 }, config.plugins.smoothcaret)
 
+local caret_idx = 1
+
 local docview_update = DocView.update
 function DocView:update()
   docview_update(self)
@@ -96,7 +98,7 @@ function DocView:update()
   end
 
   -- This is used by `DocView:draw_caret` to keep track of the current caret
-  self.caret_idx = 1
+  caret_idx = 1
 end
 
 local docview_draw_caret = DocView.draw_caret
@@ -106,11 +108,8 @@ function DocView:draw_caret(x, y)
     return
   end
 
-  local c = self.visible_carets[self.caret_idx] or { current = { x = x, y = y } }
-  local lh = self:get_line_height()
+  local c = self.visible_carets[caret_idx] or { current = { x = x, y = y } }
+  docview_draw_caret(self, c.current.x - self.scroll.x, c.current.y - self.scroll.y)
 
-  -- We use the scroll position to move back to the position relative to the window
-  renderer.draw_rect(c.current.x - self.scroll.x, c.current.y - self.scroll.y, style.caret_width, lh, style.caret)
-
-  self.caret_idx = self.caret_idx + 1
+  caret_idx = caret_idx + 1
 end


### PR DESCRIPTION
modified most (if not all) caret related plugins
- motiontrail is now aware of custom_caret, trails' color and shape matches that of cursors'
- motiontrail now works with multiple carets
- custom_caret's block cursor shows character below itself (along with characters around for when moving the cursor between characters)
- motiontrail and smoothcaret now work nicely together
- trail doesn't show when caret is hidden

although, there are some rendering problems with motiontrail that I don't know how to fix, such as it making a trail between two cursors in different docviews or said traill being affected by scrolling