### PR TITLE
language_sh: add string interpolation syntax highlighting

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -833,7 +833,7 @@
     },
     {
       "description": "Syntax for shell scripting language",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/language_sh.lua",
       "id": "language_sh",
       "mod_version": "3"

--- a/plugins/language_sh.lua
+++ b/plugins/language_sh.lua
@@ -1,7 +1,9 @@
 -- mod-version:3
 local syntax = require "core.syntax"
 
-syntax.add {
+local string_interpolation_syntax = { patterns = {}, symbols = {} }
+
+local sh_syntax = {
   name = "Shell script",
   files = { "%.sh$", "%.bash$", "^%.bashrc$", "^%.bash_profile$", "^%.profile$" },
   headers = "^#!.*bin.*sh\n",
@@ -9,90 +11,101 @@ syntax.add {
   patterns = {
     -- $# is a bash special variable and the '#' shouldn't be interpreted
     -- as a comment.
-    { pattern = "$[%a_@*#][%w_]*",                type = "keyword2" },
+    { pattern = "$[%a_@*#][%w_]*", type = "keyword2" },
     -- Comments
-    { pattern = "#.*\n",                          type = "comment"  },
+    { pattern = "#.*", type = "comment" },
     -- Strings
-    { pattern = { '"', '"', '\\' },               type = "string"   },
-    { pattern = { "'", "'", '\\' },               type = "string"   },
-    { pattern = { '`', '`', '\\' },               type = "string"   },
+    {
+      pattern = { "\"", "\"", "\\" },
+      type = "string",
+      syntax = string_interpolation_syntax,
+    },
+    { pattern = { "'", "'", "\\" }, type = "string" },
+    { pattern = { "`", "`", "\\" }, type = "string" },
     -- Ignore numbers that start with dots or slashes
-    { pattern = "%f[%w_%.%/]%d[%d%.]*%f[^%w_%.]", type = "number"   },
+    { pattern = "%f[%w_%.%/]%d[%d%.]*%f[^%w_%.]", type = "number" },
     -- Operators
-    { pattern = "[!<>|&%[%]:=*]",                 type = "operator" },
+    { pattern = "[!<>|&%[%]:=*]", type = "operator" },
+    { pattern = "+=", type = "operator" },
     -- Match parameters
-    { pattern = "%f[%S][%+%-][%w%-_:]+",          type = "function" },
-    { pattern = "%f[%S][%+%-][%w%-_]+%f[=]",      type = "function" },
+    { pattern = "%f[%S][%+%-][%w%-_:]+", type = "function" },
+    { pattern = "%f[%S][%+%-][%w%-_]+%f[=]", type = "function" },
     -- Prevent parameters with assignments from been matched as variables
-    {
-      pattern = "%s%-%a[%w_%-]*%s+()%d[%d%.]+",
-      type = { "function", "number" }
-    },
-    {
-      pattern = "%s%-%a[%w_%-]*%s+()%a[%a%-_:=]+",
-      type = { "function", "symbol" }
-    },
+    { pattern = "%s%-%a[%w_%-]*%s+()%d[%d%.]+", type = { "function", "number" } },
+    { pattern = "%s%-%a[%w_%-]*%s+()%a[%a%-_:=]+", type = { "function", "symbol" } },
     -- Match variable assignments
-    { pattern = "[_%a][%w_]+%f[%+=]",              type = "keyword2" },
+    { pattern = "[_%a][%w_]+%f[%+=]", type = "keyword2" },
     -- Match variable expansions
-    { pattern = "${.-}",                           type = "keyword2" },
-    { pattern = "$[%d$%a_@*][%w_]*",               type = "keyword2" },
+    { pattern = "${.-}", type = "keyword2" },
+    { pattern = "$[%d$%a_@*][%w_]*", type = "keyword2" },
     -- Functions
-    { pattern = "[%a_%-][%w_%-]*[%s]*%f[(]",       type = "function" },
+    { pattern = "[%a_%-][%w_%-]*[%s]*%f[(]", type = "function" },
     -- Everything else
-    { pattern = "[%a_][%w_]*",                     type = "symbol"   },
+    { pattern = "[%a_][%w_]*", type = "symbol" },
   },
   symbols = {
-    ["case"]      = "keyword",
-    ["in"]        = "keyword",
-    ["esac"]      = "keyword",
-    ["if"]        = "keyword",
-    ["then"]      = "keyword",
-    ["elif"]      = "keyword",
-    ["else"]      = "keyword",
-    ["fi"]        = "keyword",
-    ["while"]     = "keyword",
-    ["do"]        = "keyword",
-    ["done"]      = "keyword",
-    ["for"]       = "keyword",
-    ["break"]     = "keyword",
-    ["continue"]  = "keyword",
-    ["function"]  = "keyword",
-    ["local"]     = "keyword",
-    ["echo"]      = "keyword",
-    ["return"]    = "keyword",
-    ["exit"]      = "keyword",
-    ["alias"]     = "keyword",
-    ["test"]      = "keyword",
-    ["cd"]        = "keyword",
-    ["declare"]   = "keyword",
-    ["enable"]    = "keyword",
-    ["eval"]      = "keyword",
-    ["exec"]      = "keyword",
-    ["export"]    = "keyword",
-    ["getopts"]   = "keyword",
-    ["hash"]      = "keyword",
-    ["history"]   = "keyword",
-    ["help"]      = "keyword",
-    ["jobs"]      = "keyword",
-    ["kill"]      = "keyword",
-    ["let"]       = "keyword",
-    ["mapfile"]   = "keyword",
-    ["printf"]    = "keyword",
-    ["read"]      = "keyword",
+    ["case"] = "keyword",
+    ["in"] = "keyword",
+    ["esac"] = "keyword",
+    ["if"] = "keyword",
+    ["then"] = "keyword",
+    ["elif"] = "keyword",
+    ["else"] = "keyword",
+    ["fi"] = "keyword",
+    ["while"] = "keyword",
+    ["do"] = "keyword",
+    ["done"] = "keyword",
+    ["for"] = "keyword",
+    ["break"] = "keyword",
+    ["continue"] = "keyword",
+    ["function"] = "keyword",
+    ["local"] = "keyword",
+    ["echo"] = "keyword",
+    ["return"] = "keyword",
+    ["exit"] = "keyword",
+    ["alias"] = "keyword",
+    ["test"] = "keyword",
+    ["cd"] = "keyword",
+    ["declare"] = "keyword",
+    ["enable"] = "keyword",
+    ["eval"] = "keyword",
+    ["exec"] = "keyword",
+    ["export"] = "keyword",
+    ["getopts"] = "keyword",
+    ["hash"] = "keyword",
+    ["history"] = "keyword",
+    ["help"] = "keyword",
+    ["jobs"] = "keyword",
+    ["kill"] = "keyword",
+    ["let"] = "keyword",
+    ["mapfile"] = "keyword",
+    ["printf"] = "keyword",
+    ["read"] = "keyword",
     ["readarray"] = "keyword",
-    ["pwd"]       = "keyword",
-    ["select"]    = "keyword",
-    ["set"]       = "keyword",
-    ["shift"]     = "keyword",
-    ["source"]    = "keyword",
-    ["time"]      = "keyword",
-    ["type"]      = "keyword",
-    ["until"]     = "keyword",
-    ["unalias"]   = "keyword",
-    ["unset"]     = "keyword",
-    ["true"]      = "literal",
-    ["false"]     = "literal"
-  }
+    ["pwd"] = "keyword",
+    ["select"] = "keyword",
+    ["set"] = "keyword",
+    ["shift"] = "keyword",
+    ["source"] = "keyword",
+    ["time"] = "keyword",
+    ["type"] = "keyword",
+    ["until"] = "keyword",
+    ["unalias"] = "keyword",
+    ["unset"] = "keyword",
+    ["true"] = "literal",
+    ["false"] = "literal",
+  },
 }
+
+local function merge_tables(a, b) for _, v in pairs(b) do table.insert(a, v) end end
+
+merge_tables(string_interpolation_syntax.patterns, {
+  { pattern = "%$[%w_]+", type = "keyword2" },
+  { pattern = "%$[@#]", type = "keyword2" },
+  { pattern = "%${.-}", type = "keyword2" },
+  { pattern = { "%$%(", "%)" }, type = "keyword2", syntax = sh_syntax },
+  { pattern = "[%S][%w]*", type = "string" },
+})
+
+syntax.add(sh_syntax)
 


### PR DESCRIPTION
Highlighting for string interpolation in shell scripts.

There are probably edge cases that I have missed but it looks good so far.

Before - After
![Screenshot from 2023-05-23 11-19-45](https://github.com/lite-xl/lite-xl-plugins/assets/49447733/f5bfc6bd-ad70-4087-9b5f-9ced3ca62ae9)
