### PR TITLE
Fix indentation in `lfautoinsert` and add support for multiple carets

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -931,7 +931,7 @@
     },
     {
       "description": "Automatically inserts indentation and closing bracket/text after newline",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/lfautoinsert.lua",
       "id": "lfautoinsert",
       "mod_version": "3"


### PR DESCRIPTION
This also avoids using `command.perform` as it can be problematic (for example `doc:newline` behaves in different ways depending on `config.keep_newline_whitespace`).

Needs testing.