### PR TITLE
make copyfilelocation work on the treeview

### DIFF
--- a/plugins/copyfilelocation.lua
+++ b/plugins/copyfilelocation.lua
@@ -1,15 +1,35 @@
 -- mod-version:3
 local core = require "core"
 local command = require "core.command"
+local treeview = require 'plugins.treeview'
+local menu = treeview.contextmenu
 
-command.add("core.docview", {
-  ["copy-file-location:copy-file-location"] = function(dv)
-    local doc = dv.doc
+command.add("core.docview!", {
+  ["doc:copy-file-location"] = function(view)
+    local doc = view.doc
     if not doc.abs_filename then
       core.error "Cannot copy location of unsaved doc"
       return
     end
-    core.log("Copying to clipboard \"%s\"", doc.abs_filename)
+    core.log("Copying \"%s\" to clipboard", doc.abs_filename)
     system.set_clipboard(doc.abs_filename)
   end
+})
+
+command.add(function()
+  return treeview.hovered_item ~= nil
+end, {
+  ["treeview:copy-file-location"] = function()
+    local item = core.active_view.hovered_item
+    if not (item and item.abs_filename) then
+      core.error "Cannot copy location of item"
+      return
+    end
+    core.log("Copying \"%s\" to clipboard", item.abs_filename)
+    system.set_clipboard(item.abs_filename)
+  end
+})
+
+menu:register(nil, {
+  { text = "Copy file location", command = "treeview:copy-file-location" }
 })


### PR DESCRIPTION
you can now right click a file in the treeview and the option to copy it's path will be there
![image](https://github.com/lite-xl/lite-xl-plugins/assets/70547062/17a6d92a-4306-40cb-9c3f-2db347220cf5)
