### PR TITLE
Update settings.lua max log items default is 800 not 80

### DIFF
--- a/plugins/settings.lua
+++ b/plugins/settings.lua
@@ -618,7 +618,7 @@ settings.add("Development",
       description = "The maximum amount of entries to keep on the log UI.",
       path = "max_log_items",
       type = settings.type.NUMBER,
-      default = 80,
+      default = 800,
       min = 50,
       max = 2000
     },


### PR DESCRIPTION
see: https://github.com/lite-xl/lite-xl/blob/cf028c510a908a1e208588ec90b57fef422f88bf/data/core/config.lua#L6