### PR TITLE
change language_sh.lua to support .zsh

### DIFF
--- a/plugins/language_sh.lua
+++ b/plugins/language_sh.lua
@@ -3,7 +3,7 @@ local syntax = require "core.syntax"
 
 syntax.add {
   name = "Shell script",
-  files = { "%.sh$", "%.bash$", "^%.bashrc$", "^%.bash_profile$", "^%.profile$" },
+  files = { "%.sh$", "%.bash$", "^%.bashrc$", "^%.bash_profile$", "^%.profile$", "%.zsh$" },
   headers = "^#!.*bin.*sh\n",
   comment = "#",
   patterns = {


### PR DESCRIPTION
simply added .zsh to the 'files' line to highlight code in .zsh files.