### PR TITLE
`tab_switcher`: Sort entries by last focused and add "hold" mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1314,7 +1314,7 @@
     },
     {
       "description": "Switch between open tabs by searching by name",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/tab_switcher.lua",
       "id": "tab_switcher",
       "mod_version": "3"

--- a/plugins/tab_switcher.lua
+++ b/plugins/tab_switcher.lua
@@ -5,6 +5,17 @@ local keymap = require "core.keymap"
 local common = require "core.common"
 local DocView = require "core.docview"
 
+local nodes_visit_order = setmetatable({}, {__mode = "k"})
+
+local order_counter = 0
+
+local core_set_active_view = core.set_active_view
+function core.set_active_view(view)
+  nodes_visit_order[view] = order_counter
+  order_counter = order_counter + 1
+  return core_set_active_view(view)
+end
+
 local tab_switcher = {}
 function tab_switcher.get_tab_list(base_node)
   local raw_list = base_node:get_children()
@@ -21,21 +32,35 @@ function tab_switcher.get_tab_list(base_node)
       }, mt))
     end
   end
+  table.sort(list, function(a, b)
+    return (nodes_visit_order[a.view] or -1) > (nodes_visit_order[b.view] or -1)
+  end)
+  if #list > 1 then
+    -- Set last element to be the previously focused tab,
+    -- so that pressing enter is enough to switch to it.
+    local last = list[1]
+    list[1] = list[2]
+    list[2] = last
+  end
   return list
 end
 
+local function set_active_view(view)
+  local n = core.root_view.root_node:get_node_for_view(view)
+  if n then n:set_active_view(view) end
+end
+
 local function ask_selection(label, items)
-  if #items == 0 then
-    core.warn("No tabs available")
-    return
-  end
   core.command_view:enter(label, {
     submit = function(_, item)
-      local n = core.root_view.root_node:get_node_for_view(item.view)
-      if n then n:set_active_view(item.view) end
+      set_active_view(item.view)
     end,
     suggest = function(text)
-      return common.fuzzy_match(items, text, true)
+      if #text > 1 then
+        return common.fuzzy_match(items, text, true)
+      else
+        return items
+      end
     end,
     validate = function(_, item)
       return item
@@ -43,13 +68,28 @@ local function ask_selection(label, items)
   })
 end
 
-command.add(nil,{
-  ["tab-switcher:tab-list"] = function()
-    ask_selection("Switch to tab", tab_switcher.get_tab_list(core.root_view.root_node))
+command.add(function()
+    local items = tab_switcher.get_tab_list(core.root_view.root_node)
+    return #items > 0, items
+  end, {
+  ["tab-switcher:tab-list"] = function(items)
+    ask_selection("Switch to tab", items)
   end,
-  ["tab-switcher:tab-list-current-split"] = function()
-    ask_selection("Switch to tab in current split", tab_switcher.get_tab_list(core.root_view:get_active_node()))
-  end
+  ["tab-switcher:switch-to-last-tab"] = function(items)
+    set_active_view(items[1].view)
+  end,
+})
+
+command.add(function()
+    local items = tab_switcher.get_tab_list(core.root_view:get_active_node())
+    return #items > 0, items
+  end, {
+  ["tab-switcher:tab-list-current-split"] = function(items)
+    ask_selection("Switch to tab in current split", items)
+  end,
+  ["tab-switcher:switch-to-last-tab-in-current-split"] = function(items)
+    set_active_view(items[1].view)
+  end,
 })
 
 keymap.add({


### PR DESCRIPTION
The last entry in `tab-switcher:tab-list{,-current-split}` is the previously focused tab, so that pressing enter is enough to switch to  it.

Also added `tab-switcher:switch-to-last-tab{,-in-current-split}` commands.

Keymap suggestions for the new commands are welcome.