### PR TITLE
fix fatal motiontrail error when mixed with settings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1314,7 +1314,7 @@
     },
     {
       "description": "Adds a motion-trail to the caret *([gif](https://user-images.githubusercontent.com/3920290/83256814-085ccb00-a1ab-11ea-9e35-e6633cbed1a9.gif))*",
-      "version": "0.2",
+      "version": "0.3",
       "path": "plugins/motiontrail.lua",
       "id": "motiontrail",
       "mod_version": "3"

--- a/manifest.json
+++ b/manifest.json
@@ -1314,7 +1314,7 @@
     },
     {
       "description": "Adds a motion-trail to the caret *([gif](https://user-images.githubusercontent.com/3920290/83256814-085ccb00-a1ab-11ea-9e35-e6633cbed1a9.gif))*",
-      "version": "0.3",
+      "version": "0.2.1",
       "path": "plugins/motiontrail.lua",
       "id": "motiontrail",
       "mod_version": "3"

--- a/plugins/motiontrail.lua
+++ b/plugins/motiontrail.lua
@@ -90,7 +90,7 @@ function DocView:draw_caret(x, y)
   self.last_doc_pos[caret_idx] = self.last_doc_pos[caret_idx] or {}
   local line, col = self.doc:get_selection_idx(caret_idx)
 
-  if self.draws <= 1 then
+  if (self.draws or 0) <= 1 then
     local lsx, lsy = self.last_pos[caret_idx][1] or x, self.last_pos[caret_idx][2] or y
     local lsl, lsc = self.last_doc_pos[caret_idx][1], self.last_doc_pos[caret_idx][2]
     local w, h = get_caret_size(self, caret_idx)


### PR DESCRIPTION
when using settings, clicking on a widget with text capabilities fatally crashes Lite XL
this is a quick hack to fix the issue, but this should be checked on further
(and with "this should be checked" I mean "I should check this")