### PR TITLE
Added syntax support for JSON files

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -874,6 +874,14 @@
       "tags": ["language"]
     },
     {
+      "description": "Syntax for the [JSON](https://www.json.org/json-en.html) language",
+      "version": "0.1",
+      "path": "plugins/language_json.lua",
+      "id": "language_json",
+      "mod_version": "3",
+      "tags": ["language"]
+    },
+    {
       "description": "Syntax for the [Julia](https://julialang.org/) programming language",
       "version": "0.1",
       "path": "plugins/language_julia.lua",

--- a/manifest.json
+++ b/manifest.json
@@ -106,6 +106,7 @@
         "language_java": {},
         "language_jiyu": {},
         "language_jsx": {},
+        "language_json": {},
         "language_julia": {},
         "language_ksy": {},
         "language_lilypond": {},

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -1,4 +1,4 @@
--- mod-version:3
+-- mod-version:3 priority:90
 
 local syntax = require "core.syntax"
 

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -1,4 +1,4 @@
--- mod-version:3 priority:90
+-- mod-version:3
 
 local syntax = require "core.syntax"
 
@@ -8,8 +8,8 @@ syntax.add {
   comment = nil,
   patterns = {
 
-    { pattern = '\"[a-zA-Z0-9_]*\":', type = "keyword" }, -- key
-    { pattern = { '"', '"', "\\"}, type = "string" }, -- value
+    { pattern = '\"[a-zA-Z0-9_ -]*\":', type = "keyword" }, -- key
+    { pattern = '\"[^\n]*"', type = "keyword" }, -- value
 
     -- numbers
     { pattern = "0x[%da-fA-F]+", type = "number" },

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -4,9 +4,14 @@ local syntax = require "core.syntax"
 
 syntax.add {
   name = "JSON",
-  files = { "%.json$" },
+  files = { "%.json$", "%.cjson$" },
   comment = nil,
   patterns = {
+  
+    -- cjson support
+    { pattern = "//.-\n", type = "comment" },
+    { pattern = { "/%*", "%*/" }, type = "comment" },
+    
     { pattern = '"[^\n]*"%s*:', type = "keyword" }, -- key
     { pattern = '"[^\n]*"', type = "string" }, -- value
     { pattern = "0x[%da-fA-F]+", type = "number" },

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -4,7 +4,7 @@ local syntax = require "core.syntax"
 
 syntax.add {
   name = "JSON",
-  files = { "%.json$", "%.cjson$" },
+  files = { "%.json$", "%.cjson$", "%.jsonc$" },
   comment = "//",
   block_comment = {"/*", "*/"},
   patterns = {

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -13,7 +13,7 @@ syntax.add {
     { pattern = "//.*", type = "comment" },
     { pattern = { "/%*", "%*/" }, type = "comment" },
     
-    { pattern = '"[^\n]-"%s*:', type = "keyword" }, -- key
+    { pattern = '"[^\n]-"()%s*:', type = "normal" }, -- key
     { pattern = '"[^\n]-"', type = "string" }, -- value
     { pattern = "0x[%da-fA-F]+", type = "number" },
     { pattern = "-?%d+[%d%.eE]*",  type = "number" },

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -5,7 +5,8 @@ local syntax = require "core.syntax"
 syntax.add {
   name = "JSON",
   files = { "%.json$", "%.cjson$" },
-  comment = nil,
+  comment = "//",
+  block_comment = {"/*", "*/"},
   patterns = {
   
     -- cjson support

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -1,4 +1,4 @@
--- mod-version:3 priority:90
+-- mod-version:3 priority:110
 
 local syntax = require "core.syntax"
 
@@ -7,8 +7,8 @@ syntax.add {
   files = { "%.json$" },
   comment = nil,
   patterns = {
-    { pattern = '\"[a-zA-Z0-9_ -]*\":', type = "keyword" }, -- key
-    { pattern = '\"[^\n]*"', type = "string" }, -- value
+    { pattern = '"[^\n]*"%s*:', type = "keyword" }, -- key
+    { pattern = '"[^\n]*"', type = "string" }, -- value
     { pattern = "0x[%da-fA-F]+", type = "number" },
     { pattern = "-?%d+[%d%.eE]*",  type = "number" },
     { pattern = "-?%.?%d+", type = "number" },

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -7,16 +7,11 @@ syntax.add {
   files = { "%.json$" },
   comment = nil,
   patterns = {
-
     { pattern = '\"[a-zA-Z0-9_ -]*\":', type = "keyword" }, -- key
-    { pattern = '\"[^\n]*"', type = "keyword" }, -- value
-
-    -- numbers
+    { pattern = '\"[^\n]*"', type = "string" }, -- value
     { pattern = "0x[%da-fA-F]+", type = "number" },
     { pattern = "-?%d+[%d%.eE]*",  type = "number" },
     { pattern = "-?%.?%d+", type = "number" },
-
-    -- literals
     { pattern = "null", type = "literal" },
     { pattern = "true", type = "literal" },
     { pattern = "false", type = "literal" }

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -13,8 +13,8 @@ syntax.add {
     { pattern = "//.*", type = "comment" },
     { pattern = { "/%*", "%*/" }, type = "comment" },
     
-    { pattern = '"[^\n]-"()%s*:', type = "normal" }, -- key
-    { pattern = '"[^\n]-"', type = "string" }, -- value
+    { regex = [["(?:[^"\\]|\\.)*"()\s*:]], type = { "keyword", "normal" } }, -- key
+    { regex = [["(?:[^"\\]|\\.)*"]], type = "string" }, -- value
     { pattern = "0x[%da-fA-F]+", type = "number" },
     { pattern = "-?%d+[%d%.eE]*",  type = "number" },
     { pattern = "-?%.?%d+", type = "number" },

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -10,7 +10,7 @@ syntax.add {
   patterns = {
   
     -- cjson support
-    { pattern = "//.-\n", type = "comment" },
+    { pattern = "//.*", type = "comment" },
     { pattern = { "/%*", "%*/" }, type = "comment" },
     
     { pattern = '"[^\n]*"%s*:', type = "keyword" }, -- key

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -8,8 +8,7 @@ syntax.add {
   comment = nil,
   patterns = {
 
-    { pattern = '\"[a-zA-Z0-9_]*\":', type = "keyword" }, -- key (string)
-    { pattern = '[0-9_]*:', type = "keyword" }, -- key (int)
+    { pattern = '\"[a-zA-Z0-9_]*\":', type = "keyword" }, -- key
     { pattern = { '"', '"', "\\"}, type = "string" }, -- value
 
     -- numbers
@@ -18,11 +17,10 @@ syntax.add {
     { pattern = "-?%.?%d+", type = "number" },
 
     -- literals
-    { pattern = "NaN", type = "literal" },
-    { pattern = "Infinity", type = "literal" },
     { pattern = "null", type = "literal" },
     { pattern = "true", type = "literal" },
     { pattern = "false", type = "literal" }
   },
   symbols = { }
 }
+

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -1,0 +1,28 @@
+-- mod-version:3
+
+local syntax = require "core.syntax"
+
+syntax.add {
+  name = "JSON",
+  files = { "%.json$" },
+  comment = nil,
+  patterns = {
+
+    { pattern = '\"[a-zA-Z0-9_]*\":', type = "keyword" }, -- key (string)
+    { pattern = '[0-9_]*:', type = "keyword" }, -- key (int)
+    { pattern = { '"', '"', "\\"}, type = "string" }, -- value
+
+    -- numbers
+    { pattern = "0x[%da-fA-F]+", type = "number" },
+    { pattern = "-?%d+[%d%.eE]*",  type = "number" },
+    { pattern = "-?%.?%d+", type = "number" },
+
+    -- literals
+    { pattern = "NaN", type = "literal" },
+    { pattern = "Infinity", type = "literal" },
+    { pattern = "null", type = "literal" },
+    { pattern = "true", type = "literal" },
+    { pattern = "false", type = "literal" }
+  },
+  symbols = { }
+}

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -13,8 +13,8 @@ syntax.add {
     { pattern = "//.*", type = "comment" },
     { pattern = { "/%*", "%*/" }, type = "comment" },
     
-    { pattern = '"[^\n]*"%s*:', type = "keyword" }, -- key
-    { pattern = '"[^\n]*"', type = "string" }, -- value
+    { pattern = '"[^\n]-"%s*:', type = "keyword" }, -- key
+    { pattern = '"[^\n]-"', type = "string" }, -- value
     { pattern = "0x[%da-fA-F]+", type = "number" },
     { pattern = "-?%d+[%d%.eE]*",  type = "number" },
     { pattern = "-?%.?%d+", type = "number" },


### PR DESCRIPTION
Looks cleaner than the default syntax `language_js` gives

Example:
![2023-11-05-234949_380x215_scrot](https://github.com/lite-xl/lite-xl-plugins/assets/125209101/524be0ca-f061-4e73-ad19-c79c37361f74)
