### PR TITLE
Fix Haskell comments, add block_comment

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -61,7 +61,7 @@
     {
       "id": "meta_languages",
       "type": "meta",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "mod_version": "3",
       "description": "A metapackage containing all publically accessible language syntaxes.",
       "dependencies": {
@@ -817,7 +817,7 @@
     },
     {
       "description": "Syntax for the [Haskell](https://www.haskell.org/) programming language",
-      "version": "0.1",
+      "version": "0.2",
       "path": "plugins/language_hs.lua",
       "id": "language_hs",
       "mod_version": "3",

--- a/plugins/language_hs.lua
+++ b/plugins/language_hs.lua
@@ -4,7 +4,8 @@ local syntax = require "core.syntax"
 syntax.add {
   name = "Haskell",
   files = { "%.hs$" },
-  comment = "%-%-",
+  comment = "--",
+  block_comment = {"{-", "-}"},
   patterns = {
     { pattern = {"%-%-", "\n"},         type = "comment"  },
     { pattern = { "{%-", "%-}" },       type = "comment"  },


### PR DESCRIPTION
`-` Was incorrectly escaped before