### PR TITLE
lite-debugger improvements

### DIFF
--- a/plugins/lite-debugger.lua
+++ b/plugins/lite-debugger.lua
@@ -520,6 +520,7 @@ local commands = {
 }
 
 local function match_command(line)
+   line = line:gsub("^%s+", ""):gsub("%s*$", "")
    for pat, func in pairs(commands) do
       -- Return the matching command and capture argument.
       if line:find(pat) then return func, line:match(pat) end

--- a/plugins/lite-debugger.lua
+++ b/plugins/lite-debugger.lua
@@ -275,6 +275,7 @@ local line_breakpoints = 0
 local debug_hook
 
 local function cmd_break(func_name)
+   func_name = func_name:gsub("[\\/]", package.config:sub(1, 1))
    if func_name:find(":%d+$") ~= nil then line_breakpoints = line_breakpoints + 1 end
    table.insert(break_funcs, func_name)
    break_funcs[func_name] = true
@@ -509,8 +510,13 @@ function debug_hook(offset, reason)
       if #s.namewhat > 0 then
          local i = split(s.short_src, "/")
          local long_name = i[#i]..":"..s.name
+         local longer_name = s.short_src..":"..s.name
+         local long_linenum = i[#i]..":"..s.currentline
+         local longer_linenum = s.short_src..":"..s.currentline
 
-         if in_array(break_funcs, long_name) or in_array(break_funcs, s.name) then
+         if break_funcs[longer_name] or break_funcs[longer_linenum]
+            or break_funcs[long_name] or break_funcs[long_linenum]
+            or break_funcs[s.name] then
             offset = offset - 1
             repl(reason)
          end

--- a/plugins/lite-debugger.lua
+++ b/plugins/lite-debugger.lua
@@ -1,6 +1,7 @@
 -- mod-version:3
 
 local command = require "core.command"
+local common = require "core.common"
 local core = require "core"
 
 --[[
@@ -275,8 +276,12 @@ local line_breakpoints = 0
 local debug_hook
 
 local function cmd_break(func_name)
-   func_name = func_name:gsub("[\\/]", package.config:sub(1, 1))
-   if func_name:find(":%d+$") ~= nil then line_breakpoints = line_breakpoints + 1 end
+   if func_name:find(":") then
+      local filename, linenum = func_name:match("^(.+):(.+)$")
+      filename = common.normalize_path(system.absolute_path(common.home_expand(filename)))
+      func_name = filename..":"..linenum
+      if tonumber(linenum) then line_breakpoints = line_breakpoints + 1 end
+   end
    table.insert(break_funcs, func_name)
    break_funcs[func_name] = true
    debug.sethook(debug_hook(0), "crl")

--- a/plugins/lite-debugger.lua
+++ b/plugins/lite-debugger.lua
@@ -286,6 +286,20 @@ local function cmd_delete(index)
    return false
 end
 
+local function cmd_list_breakpoint()
+   for i, func_name in ipairs(break_funcs) do
+      local pretty_name
+      if func_name:find(":") then
+         local filename, linenum = func_name:match("^(.+):(.+)$")
+         local linenum_color = tonumber(linenum) and COLOR_YELLOW or COLOR_BLUE
+         pretty_name = COLOR_BLUE..filename..COLOR_RESET..":"..linenum_color..linenum
+      else
+         pretty_name = COLOR_BLUE..func_name
+      end
+      dbg.writeln("%s % 4d: %s", COLOR_RESET, i, pretty_name)
+   end
+end
+
 local function cmd_step()
    stack_inspect_offset = stack_top
    return true, hook_step
@@ -434,6 +448,7 @@ local function cmd_help()
       .. COLOR_BLUE.."  c"..COLOR_YELLOW.."(ontinue)"..GREEN_CARET.."continue execution\n"
       .. COLOR_BLUE.."  b"..COLOR_YELLOW.."(reak) "..COLOR_BLUE.."[[file:]function]"..GREEN_CARET.."set breakpoint at specified function\n"
       .. COLOR_BLUE.."  d"..COLOR_YELLOW.."(elete) "..COLOR_BLUE.."[index]"..GREEN_CARET.."remove breakpoint\n"
+      .. COLOR_BLUE.."  r"..COLOR_YELLOW.."(list)"..GREEN_CARET.."list all breakpoints\n"
       .. COLOR_BLUE.."  s"..COLOR_YELLOW.."(tep)"..GREEN_CARET.."step forward by one line (into functions)\n"
       .. COLOR_BLUE.."  n"..COLOR_YELLOW.."(ext)"..GREEN_CARET.."step forward by one line (skipping over functions)\n"
       .. COLOR_BLUE.."  f"..COLOR_YELLOW.."(inish)"..GREEN_CARET.."step forward until exiting the current function\n"
@@ -505,6 +520,7 @@ local commands = {
    ["^c$"] = cmd_continue,
    ["^b%s+(.*)$"] = cmd_break,
    ["^d%s+(%d*)$"] = cmd_delete,
+   ["^r$"] = cmd_list_breakpoint,
    ["^s$"] = cmd_step,
    ["^n$"] = cmd_next,
    ["^f$"] = cmd_finish,


### PR DESCRIPTION
This PR adds a few improvements to the debugger:

1. hooks are unset if no breakpoints are set.
2. added support for full path breakpoints (e.g. `~/.config/lite-xl/init.lua:blabla` instead of only `init.lua`, which could literally be any module)
3. added a command to list all breakpoints
4. allow spaces before and after a command

cc @Jan200101 since iirc you're the one who added this plugin initially