### PR TITLE
Add lsp_python

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1466,7 +1466,7 @@
     },
     {
       "description": "File icons set for TreeView. Modification of the [nonicons](plugins/nonicons.lua) plugin. Uses [NerdFont](https://www.nerdfonts.com/) icons",
-      "version": "1.2",
+      "version": "1.2.1",
       "type": "plugin",
       "path": "plugins/nerdicons.lua",
       "id": "nerdicons",

--- a/manifest.json
+++ b/manifest.json
@@ -1387,6 +1387,13 @@
       "id": "lsp_lua"
     },
     {
+      "description": "Automatic configuration/binary download for LSP completion for Python with Pyright.",
+      "version": "1.1.351",
+      "remote": "https://github.com/adamharrison/lite-xl-lsp-servers:e2ec4cb92ceb58c3d0214919e715e5e1903c6633",
+      "mod_version": "3",
+      "id": "lsp_python"
+    },
+    {
       "description": "Automatic configuration/binary download for LSP linting for Javascript with quick-lint-js.",
       "version": "3.1.0",
       "remote": "https://github.com/adamharrison/lite-xl-lsp-servers:69c85033c8a62214d1e758d986cb2eea7a66728e",

--- a/manifest.json
+++ b/manifest.json
@@ -1483,6 +1483,14 @@
       }
     },
     {
+      "description": "Provides official NodeJs binaries",
+      "version": "20.11.1",
+      "type": "library",
+      "remote": "https://github.com/adamharrison/lite-xl-lsp-servers:e2ec4cb92ceb58c3d0214919e715e5e1903c6633",
+      "mod_version": "3",
+      "id": "nodejs"
+    },
+    {
       "description": "File icons set for TreeView. Uses the [Nonicons](https://github.com/yamatsum/nonicons/) font",
       "version": "0.4",
       "path": "plugins/nonicons.lua",


### PR DESCRIPTION
Updates `manifest.json`, in order to link the newly added `lsp_python` addon and the `nodejs` library