### PR TITLE
Update indentguide: Set the curent guide line highlight as optional

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -545,7 +545,7 @@
     },
     {
       "description": "Adds indent guides *([screenshot](https://user-images.githubusercontent.com/3920290/79640716-f9860000-818a-11ea-9c3b-26d10dd0e0c0.png))*",
-      "version": "0.1",
+      "version": "0.1.1",
       "path": "plugins/indentguide.lua",
       "id": "indentguide",
       "mod_version": "3"

--- a/manifest.json
+++ b/manifest.json
@@ -545,7 +545,7 @@
     },
     {
       "description": "Adds indent guides *([screenshot](https://user-images.githubusercontent.com/3920290/79640716-f9860000-818a-11ea-9c3b-26d10dd0e0c0.png))*",
-      "version": "0.1.1",
+      "version": "0.2",
       "path": "plugins/indentguide.lua",
       "id": "indentguide",
       "mod_version": "3"

--- a/plugins/indentguide.lua
+++ b/plugins/indentguide.lua
@@ -6,6 +6,7 @@ local DocView = require "core.docview"
 
 config.plugins.indentguide = common.merge({
   enabled = true,
+  highlight = true,
   -- The config specification used by the settings gui
   config_spec = {
     name = "Indent Guide",
@@ -13,6 +14,13 @@ config.plugins.indentguide = common.merge({
       label = "Enable",
       description = "Toggle the drawing of indentation indicator lines.",
       path = "enabled",
+      type = "toggle",
+      default = true
+    },
+    {
+      label = "Highlight Line",
+      description = "Toggle the highlight of the curent indentation indicator lines.",
+      path = "highlight",
       type = "toggle",
       default = true
     }
@@ -133,7 +141,9 @@ function DocView:draw_line_text(line, x, y)
     for i = 0, spaces - 1, indent_size do
       local color = style.guide or style.selection
       local active_lvl = self.indentguide_indent_active[line] or -1
-      if i < active_lvl and i + indent_size >= active_lvl then
+      if i < active_lvl 
+      and i + indent_size >= active_lvl
+      and config.plugins.indentguide.highlight then
         color = style.guide_highlight or style.accent
       end
       local sw = space_sz * i


### PR DESCRIPTION
Before:
![image](https://github.com/lite-xl/lite-xl-plugins/assets/93390411/fa136ed4-c10a-4f02-8e2e-442948e53210)

After:
![image](https://github.com/lite-xl/lite-xl-plugins/assets/93390411/f2815d3d-b1d1-4cd2-a070-36f8d2eb91ab)
