### PR TITLE
eval:selected multi-cursor support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -422,7 +422,7 @@
       "id": "eval",
       "mod_version": "3",
       "path": "plugins/eval.lua",
-      "version": "0.1"
+      "version": "0.2"
     },
     {
       "description": "Adds Treesitter syntax highlighting support",

--- a/plugins/eval.lua
+++ b/plugins/eval.lua
@@ -33,13 +33,14 @@ command.add("core.docview", {
   end,
 
   ["eval:selected"] = function(dv)
-    if dv.doc:has_selection() then
-      local text = dv.doc:get_text(dv.doc:get_selection())
-      dv.doc:text_input(eval(text))
-    else
-      local line = dv.doc:get_selection()
-      local text = dv.doc.lines[line]
-      dv.doc:insert(line+1, 0, "= " .. eval(text) .. "\n")
+    for idx, line1, col1, line2, col2 in dv.doc:get_selections() do
+      if line1 ~= line2 or col1 ~= col2 then
+        local text = dv.doc:get_text(line1, col1, line2, col2)
+        dv.doc:text_input(eval(text), idx)
+      else
+        local text = dv.doc.lines[line1]
+        dv.doc:replace_cursor(idx, line1, 0, line1, #text, eval)
+      end
     end
   end,
 })


### PR DESCRIPTION
This PR makes it so that if you run `eval:selected` while having multiple selections, it will evaluate and replace the contents of each, rather than replacing all selections with the first result.

Note: some previous functionality:

> if no text is selected, eval the current line and insert the result in the next line with "= " prefix. (https://github.com/lite-xl/lite-xl-plugins/pull/177)

has been removed as it doesn't play nice with multiple selections. Now it behaves as if the whole line had been selected, and replaces the line. Maybe @Titousensei could confirm that this is ok / won't ruin your workflow?