### PR TITLE
Update language_umka.lua

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1552,7 +1552,7 @@
       "tags": [
         "language"
       ],
-      "version": "0.1"
+      "version": "0.2"
     },
     {
       "description": "Syntax for the [Tcl](https://www.tcl.tk/) programming language",

--- a/plugins/language_umka.lua
+++ b/plugins/language_umka.lua
@@ -19,7 +19,9 @@ syntax.add {
 		{ pattern = "%.%.",                            type = "operator" },
 		{ pattern = "[%^%+%-%*/%%&|~<>!=]",            type = "operator" },
 		{ pattern = "[%a_][%w_]*()%*?()%s*%f[%(]",     type = {"function", "operator", "normal"} },
-		{ pattern = "%u[%w_]*",                        type = "literal"  },
+		{ pattern = "%u[%w_]*%.()%u[%w_]*",            type = {"normal", "literal"}  },
+		{ pattern = "%.?%u[%w_]*",                     type = "literal"  },
+		{ pattern = "[%a_][%w_]*::",                   type = "keyword2" },
 		{ pattern = "[%a_][%w_]*",                     type = "symbol"   },
 	},
 	symbols = {


### PR DESCRIPTION
most generic title ever but it works

Umka 1.4 shipped with a new, easier to detect syntax for modules:
![imagen](https://github.com/lite-xl/lite-xl-plugins/assets/70547062/00cc70a8-8a13-452a-a072-2c62c8140825)
![Captura desde 2024-06-06 10-41-57](https://github.com/lite-xl/lite-xl-plugins/assets/70547062/be739879-67ac-475d-9688-6382fbad5f34)

you can also omit the typename of an enumeration:
![imagen](https://github.com/lite-xl/lite-xl-plugins/assets/70547062/7d3fcd97-1c00-4415-a444-e6fc86a17db3)

and I made it so that the enum variant highlights but not the enum type:
![Captura desde 2024-06-06 10-41-39](https://github.com/lite-xl/lite-xl-plugins/assets/70547062/fbaecb22-6dcb-49d6-927c-ca744d0e949b)
