### PR TITLE
Fix codeplus mod_version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -255,7 +255,7 @@
     {
       "description": "Offers improvements such as highlighted comments and autocomplete for brackets, quotes and more. ([demo](https://s12.gifyu.com/images/Sckre.gif))",
       "id": "codeplus",
-      "mod_version": 3,
+      "mod_version": "3",
       "remote": "https://github.com/chqs-git/code-plus.git:b336999b707709df2ddcb865f664623c5beceabb",
       "version": "1.0"
     },


### PR DESCRIPTION
As explicitly written on the specification mod_version is a string and  I think that is better to not introduce more ambiguity on the manifest in order to simplify parsing, even if I personally prefer mod_version as a simple incremental integer number instead of a string, I think it would be better to encourage a stronger standard