### PR TITLE
Update nerdicons

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1888,7 +1888,7 @@
       "mod_version": "3",
       "path": "plugins/nerdicons.lua",
       "type": "plugin",
-      "version": "1.2.2"
+      "version": "1.2.3"
     },
     {
       "description": "Official NodeJs builds.",

--- a/plugins/nerdicons.lua
+++ b/plugins/nerdicons.lua
@@ -113,6 +113,10 @@ local extension_icons = {
   [".otf"]         = { "#dad8d4", "fa-font"                  },
   [".vim"]         = { "#8f00ff", "custom-vim"               },
   [".pdf"]         = { "#E53935", "fa-file_pdf_o"            },
+  [".jl"]          = { "#4063d8", "seti-julia"               },
+  [".mp4"]         = { "#e85e00", "oct-video"                },
+  [".jld2"]        = { "#888888", "fa-database"              },
+  [".ipynb"]       = { "#F37726", "seti-notebook"            },
 }
 
 
@@ -122,7 +126,6 @@ local known_filenames_icons = {
   [".gitmodules"]     = { "#cc3e56", "dev-git"              },
   ["PKGBUILD"]        = { "#6d8ccc", "md-package"           },
   ["license"]         = { "#d0bf41", "seti-license"         },
-  ["copying"]         = { "#d0bf41", "seti-license"         },
   ["makefile"]        = { "#d0bf41", "dev-gnu"              },
   ["cmakelists.txt"]  = { "#cc3e55", "md-triangle_outline"  },
 }

--- a/plugins/nerdicons.lua
+++ b/plugins/nerdicons.lua
@@ -126,6 +126,7 @@ local known_filenames_icons = {
   [".gitmodules"]     = { "#cc3e56", "dev-git"              },
   ["PKGBUILD"]        = { "#6d8ccc", "md-package"           },
   ["license"]         = { "#d0bf41", "seti-license"         },
+  ["copying"]         = { "#d0bf41", "seti-license"         },
   ["makefile"]        = { "#d0bf41", "dev-gnu"              },
   ["cmakelists.txt"]  = { "#cc3e55", "md-triangle_outline"  },
 }


### PR DESCRIPTION
This small PR adds some more icons to the `nerdicons` plugin. 

Those icons are:

- julia files
- mp4 files
- jld2 (subset of the HDF5 file format for julia)
- jupyter notebook files (I did not find the jupyter logo in the nerdfonts library so instead I put the symbol of a regular notebook)