### PR TITLE
Update language.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1160,7 +1160,7 @@
       "tags": [
         "language"
       ],
-      "version": "0.1"
+      "version": "0.1.1"
     },
     {
       "description": "Syntax for the [Julia](https://julialang.org/) programming language",

--- a/plugins/language_json.lua
+++ b/plugins/language_json.lua
@@ -4,7 +4,14 @@ local syntax = require "core.syntax"
 
 syntax.add {
   name = "JSON",
-  files = { "%.json$", "%.cjson$", "%.jsonc$" },
+  
+  files = { 
+    "%.json$",
+    "%.cjson$",
+    "%.jsonc$",
+    "%.ipynb$",
+  },
+  
   comment = "//",
   block_comment = {"/*", "*/"},
   patterns = {


### PR DESCRIPTION
This very small PR adds support for `.ipynb` files (raw jupyter notebook) to be displayed with the json syntax when opened in Lite-xl.