### PR TITLE
Fix `language_htaccess` using capture groups

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1108,7 +1108,7 @@
       "tags": [
         "language"
       ],
-      "version": "0.1"
+      "version": "0.1.1"
     },
     {
       "description": "Syntax for [.gitignore](https://git-scm.com/docs/gitignore), [.dockerignore](https://docs.docker.com/engine/reference/builder/#dockerignore-file) and some other `.*ignore` files",

--- a/plugins/language_htaccess.lua
+++ b/plugins/language_htaccess.lua
@@ -187,7 +187,7 @@ syntax.add {
     -- IPs
     { pattern = "%d+%.%d+%.%d+%.%d+",           type = "keyword2" },
     { pattern = "%d+%.%d+%.%d+%.%d+/%d+",       type = "keyword2" },
-    { regex   = "([a-f0-9:]+:+)+[a-f0-9]+",     type = "keyword2" },
+    { regex   = [[(?:[a-fA-F0-9]*:)+(?:[a-fA-F0-9]+|:)(?:\/[0-9]+)?]], type = "keyword2" },
     -- Emails
     { pattern = "%w+@%w+%.%w+",                 type = "keyword2" },
     -- Rewrite option sections

--- a/plugins/language_htaccess.lua
+++ b/plugins/language_htaccess.lua
@@ -165,11 +165,11 @@ local xml_syntax = {
 
 syntax.add {
   name = ".htaccess File",
-  files = { "^%.htaccess$" },
+  files = { PATHSEP .. "%.htaccess$" },
   comment = "#",
   patterns = {
     -- Comments
-    { pattern = "#.*\n",                        type = "comment"  },
+    { pattern = "#.*",                          type = "comment"  },
     -- Strings
     { pattern = { '"', '"', '\\' },             type = "string"   },
     { pattern = { "'", "'", '\\' },             type = "string"   },
@@ -191,14 +191,14 @@ syntax.add {
     -- Emails
     { pattern = "%w+@%w+%.%w+",                 type = "keyword2" },
     -- Rewrite option sections
-    { pattern = "%f[%S]%b[]",                   type = "number" },
+    { pattern = "%f[%S]%b[]",                   type = "number"   },
     -- XML tags
     { pattern = { "</?%w+", ">" },              type = "literal", syntax = xml_syntax },
     -- Variables
     { pattern = "[%%$]%d+",                     type = "keyword2" },
     { pattern = "[%%$]%{[%w_:%-]+%}",           type = "keyword2" },
     -- Numbers
-    { pattern = "A?%d+",                        type = "number" },
+    { pattern = "A?%d+",                        type = "number"   },
     -- Operators
     { pattern = "%f[%S][!=+%-]+",               type = "operator" },
     -- Regex (TODO: improve this, it's pretty naive and only works on some regex)
@@ -206,7 +206,7 @@ syntax.add {
     { pattern = "%f[^%s!]%S*%$",                type = "literal" },
     { pattern = "%f[^%s!]%b()",                 type = "literal" },
     -- Everything else
-    { pattern = "[%a_][%w_-]*",                 type = "symbol"   },
+    { pattern = "[%a_][%w_-]*",                 type = "symbol"  },
   },
   symbols = symbols
 }


### PR DESCRIPTION
* Removed capture group from regex
* Correctly match files named exactly `.htaccess`

The previous regex was also possibly not safe from ReDoS.