### PR TITLE
Add .zprofile and .zshrc to `language_sh` and fix header pattern.

### DIFF
--- a/plugins/language_sh.lua
+++ b/plugins/language_sh.lua
@@ -3,8 +3,8 @@ local syntax = require "core.syntax"
 
 syntax.add {
   name = "Shell script",
-  files = { "%.sh$", "%.bash$", "^%.bashrc$", "^%.bash_profile$", "^%.profile$", "%.zsh$", "%.fish$" },
-  headers = "^#!.*bin.*sh\n",
+  files = { "%.sh$", "%.bash$", "^%.bashrc$", "^%.bash_profile$", "^%.profile$", "^%.zprofile$", "%.zsh$", "%.zshrc$", "%.fish$" },
+  headers = "^#!.*bin.*sh",
   comment = "#",
   patterns = {
     -- $# is a bash special variable and the '#' shouldn't be interpreted


### PR DESCRIPTION
Now `.zshrc` gets recognized and scripts that have flags in their shebang also work.

However my `.zprofile` still doesn't work 🤔

When completed this will fix all the issues at #469