### PR TITLE
deleted lite-xl-vibe

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2305,7 +2305,10 @@
       "replaces": [
         "vibe"
       ],
-      "version": "0.1"
+      "tags": [
+        "deprecated"
+      ],
+      "version": "0.2"
     },
     {
       "description": "Audio visualizer for Lite XL",


### PR DESCRIPTION
I believe the plugin is waay behind the current lite-xl (as it was developed mainly several years ago and not in any way finished at that time)