### PR TITLE
Fix `for` keyword match in `language_sh`.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1595,7 +1595,7 @@
       "tags": [
         "language"
       ],
-      "version": "0.2"
+      "version": "0.2.1"
     },
     {
       "description": "Syntax for ssh & sshd config files",

--- a/plugins/language_sh.lua
+++ b/plugins/language_sh.lua
@@ -37,10 +37,10 @@ syntax.add {
     -- Match variable expansions
     { pattern = "${.-}",                           type = "keyword2" },
     { pattern = "$[%d$%a_@*][%w_]*",               type = "keyword2" },
-    -- Functions
-    { pattern = "[%a_%-][%w_%-]*[%s]*%f[(]",       type = "function" },
     -- Everything else
     { pattern = "[%a_][%w_]*",                     type = "symbol"   },
+    -- Functions
+    { pattern = "[%a_%-][%w_%-]*[%s]*%f[(]",       type = "function" },
   },
   symbols = {
     ["case"]      = "keyword",


### PR DESCRIPTION
Fix the `for` keyword getting matched as `function` and not `keyword2` when in c++-like loop form.
To fix it, I just changed the priority of the pattern for all symbols.