### PR TITLE
Move my plugins into main repo

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -969,7 +969,7 @@
       "description": "Syntax for the [env](https://hexdocs.pm/dotenvy/dotenv-file-format.html) (dotenv) files",
       "id": "language_env",
       "mod_version": "3",
-      "remote": "https://github.com/anthonyaxenov/lite-xl-env-syntax:89a4274af6a786963930d7a8fb542dfe61daa801",
+      "path": "plugins/language_env.lua",
       "tags": [
         "language"
       ],
@@ -1159,7 +1159,7 @@
       "description": "Syntax for [.gitignore](https://git-scm.com/docs/gitignore), [.dockerignore](https://docs.docker.com/engine/reference/builder/#dockerignore-file) and some other `.*ignore` files",
       "id": "language_ignore",
       "mod_version": "3",
-      "remote": "https://github.com/anthonyaxenov/lite-xl-ignore-syntax:3a9a5e0ae03b82358473da5d1c6012944d65ea95",
+      "path": "plugins/language_ignore.lua",
       "tags": [
         "language"
       ],

--- a/plugins/language_env.lua
+++ b/plugins/language_env.lua
@@ -1,0 +1,68 @@
+-- mod-version:3
+
+local syntax = require "core.syntax"
+
+local key_pattern = '[a-zA-Z_]+[a-zA-Z0-9_]*'
+local unicode_sequence = "'?\\u%x%x%x%x'?"
+local escaped_literals = "\\[nrtfb\\\"']"
+local null_pattern = '%s*[Nn][Uu][Ll][Ll]%s*'
+local true_pattern = '%s*[Tt][Rr][Uu][Ee]%s*'
+local false_pattern = '%s*[Ff][Aa][Ll][Ss][Ee]%s*'
+
+local synt_key = {
+  symbols = {},
+  patterns = {
+    { type = "keyword2", pattern = key_pattern },
+  },
+}
+
+local synt_dqs = {
+  symbols = {},
+  patterns = {
+    { pattern = { "%${", "}" },     type = "keyword", syntax = synt_key },
+    { pattern = "0[bB][%d]+",       type = "number"   },
+    { pattern = "0[xX][%da-fA-F]+", type = "number"   },
+    { pattern = "[-+]?%.?%d+",      type = "number"   },
+    { pattern = escaped_literals,   type = "literal"  }, -- escaped chars
+    { pattern = unicode_sequence,   type = "literal"  }, -- unicode sequence
+    { pattern = '[%w%p%s]',         type = "string"   },
+  },
+}
+
+syntax.add {
+  name = "language_env",
+  files = { "%.env$" },
+  comment = '#',
+  symbols = {},
+  patterns = {
+    { pattern = "#.*$",           type = "comment"  },
+    { pattern = "export",         type = "function" },
+    { pattern = null_pattern,     type = "literal"  },
+    { pattern = true_pattern,     type = "literal"  },
+    { pattern = false_pattern,    type = "literal"  },
+    { pattern = escaped_literals, type = "literal"  },
+    { pattern = unicode_sequence, type = "literal"  },
+    -- interpolation
+    { pattern = { "%${", "}" },     type = "keyword", syntax = synt_key },
+    -- numbers
+    { pattern = "0[bB][%d]+",       type = "number" },
+    { pattern = "0[xX][%da-fA-F]+", type = "number" },
+    { pattern = "[-+]?%.?%d+",      type = "number" },
+    -- keys
+    { pattern = '[\'"].*[\'"]%s*=.*',     type = "normal" },
+    -- {
+    --   pattern = '[\'"]?'..escaped_literals..'[\'"]?%s*=.*',
+    --   type = "normal"
+    -- },
+    -- {
+    --   pattern = '[\'"]?'..null_pattern..'[\'"]?%s*=.*',
+    --   type = "normal"
+    -- },
+    { pattern = key_pattern..'%s*()=%s*', type = { "keyword2", "operator" }},
+    -- quoted strings
+    { pattern = {'"', '"', '\\'},     type = "string",  syntax = synt_dqs},
+    { pattern = {"'", "'", '\\'},     type = "string"   },
+    { pattern = {'"""', '"""', '\\'}, type = "string"   },
+    { pattern = {"'''", "'''", '\\'}, type = "string"   },
+  },
+}

--- a/plugins/language_ignore.lua
+++ b/plugins/language_ignore.lua
@@ -1,0 +1,20 @@
+-- mod-version:3
+
+local syntax = require "core.syntax"
+local style = require "core.style"
+local common = require "core.common"
+
+style.syntax["ignore"] = { common.color "#72B886" }
+style.syntax["exclude"] = { common.color "#F36161" }
+
+syntax.add {
+  name = ".ignore file",
+  files = { "%..*ignore$" },
+  comment = "#",
+  patterns = {
+    { regex = "^ *#.*$",            type = "comment" },
+    { regex = { "(?=^ *!.)", "$" }, type = "ignore"  },
+    { regex = { "(?=.)", "$" },     type = "exclude" },
+  },
+  symbols = {}
+}


### PR DESCRIPTION
I decided to move (almost) all my repositories away from github to my own gitea instance, so I want to include my plugins in the main lite-xl plugin repository as-is, so that community could maintain them and maintainers could include them in future releases