### PR TITLE
Remove devicons plugin from the list of plugins.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -317,6 +317,27 @@
       "version": "0.1"
     },
     {
+      "description": "Icons font for the devicons plugin.",
+      "id": "font_devicons",
+      "mod_version": "3",
+      "remote": "https://github.com/PerilousBooklet/lite-xl-devicons:e78f2374a1f4de5d0f324af46a07c2f9ffa7ccef",
+      "tags": [
+        "deprecated"
+      ],
+      "type": "font",
+      "version": "1.0.0"
+    },
+    {
+      "description": "PerilousBooklet's treeview icons for software developers.",
+      "id": "devicons",
+      "mod_version": "3",
+      "remote": "https://github.com/PerilousBooklet/lite-xl-devicons:e78f2374a1f4de5d0f324af46a07c2f9ffa7ccef",
+      "tags": [
+        "deprecated"
+      ],
+      "version": "1.0.0"
+    },
+    {
       "description": "Add end tags in variety of languages. Similar to [Vim Endwise](https://github.com/tpope/vim-endwise)",
       "id": "endwise",
       "mod_version": "3",

--- a/manifest.json
+++ b/manifest.json
@@ -317,21 +317,6 @@
       "version": "0.1"
     },
     {
-      "description": "Icons font for the devicons plugin.",
-      "id": "font_devicons",
-      "mod_version": "3",
-      "remote": "https://github.com/PerilousBooklet/lite-xl-devicons:e78f2374a1f4de5d0f324af46a07c2f9ffa7ccef",
-      "type": "font",
-      "version": "1.0.0"
-    },
-    {
-      "description": "PerilousBooklet's treeview icons for software developers.",
-      "id": "devicons",
-      "mod_version": "3",
-      "remote": "https://github.com/PerilousBooklet/lite-xl-devicons:e78f2374a1f4de5d0f324af46a07c2f9ffa7ccef",
-      "version": "1.0.0"
-    },
-    {
       "description": "Add end tags in variety of languages. Similar to [Vim Endwise](https://github.com/tpope/vim-endwise)",
       "id": "endwise",
       "mod_version": "3",


### PR DESCRIPTION
I decided to withdraw my custom icon fonts plugin as it's no longer in line to the standards of the more popular others and I am not going to update to the new font plugin structure.
Also, this plugin was originally meant for me, as such it contains some icon features that most would find broken (es. I color the icons following the original project icon's color, regardless of the theme currently loaded).