### PR TITLE
Fix member variable typo

### DIFF
--- a/plugins/tetris.lua
+++ b/plugins/tetris.lua
@@ -199,7 +199,7 @@ function TetrisView:new(options)
     }
   }
   self.live_piece = nil
-  self.hold_piece = nil
+  self.held_piece = nil
 end
 
 function TetrisView:calculate_tick(score)


### PR DESCRIPTION
Correcting an assumed typo given that `hold_piece` isn't used anywhere in the source file but `held_piece` is.