### PR TITLE
Pr/fix select colorscheme

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2074,7 +2074,7 @@
       "id": "select_colorscheme",
       "mod_version": "3",
       "path": "plugins/select_colorscheme.lua",
-      "version": "0.1"
+      "version": "0.2"
     },
     {
       "description": "Highlights regions of code that match the current selection *([screenshot](https://user-images.githubusercontent.com/3920290/80710883-5f597c80-8ae7-11ea-97f0-76dfacc08439.png))*",

--- a/plugins/select_colorscheme.lua
+++ b/plugins/select_colorscheme.lua
@@ -11,7 +11,7 @@ local PATH_CONFIG = USERDIR .. "/color_settings.lua"
 local Settings = {}
 Settings.color_scheme = ""
 Settings.color_list = {}
-local color_default = {name = "Default", module = "core.style"}
+local color_default = {name = "default", module = "core.style"}
 local plugin_enable = false
 
 --  =========================Proxy method==========================


### PR DESCRIPTION
If you install this plugin, and it creates a file, it then crashes your editor, because it can't load a colorscheme.