### PR TITLE
Added f80 type to syntax

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1781,7 +1781,7 @@
       "tags": [
         "language"
       ],
-      "version": "0.1"
+      "version": "0.2"
     },
     {
       "description": "Automatically inserts indentation and closing bracket/text after newline",

--- a/plugins/language_zig.lua
+++ b/plugins/language_zig.lua
@@ -87,6 +87,7 @@ syntax.add {
     ["f16"] = "keyword2",
     ["f32"] = "keyword2",
     ["f64"] = "keyword2",
+    ["f80"] = "keyword2",
     ["f128"] = "keyword2",
     ["void"]            = "keyword2",
     ["c_void"]          = "keyword2",


### PR DESCRIPTION
Added the `f80` type in to the zig language syntax. This has been defined since zig version 0.10.1 and documentation for it can be found [here](https://ziglang.org/documentation/0.10.1/#Floats).