### PR TITLE
FIX: target pattern in `language_make`

### DIFF
--- a/plugins/language_make.lua
+++ b/plugins/language_make.lua
@@ -11,8 +11,8 @@ syntax.add {
     { pattern = "$[@^<%%?+|*]",           type = "keyword2" },
     { pattern = "$%(.-%)",                type = "symbol"   },
     { pattern = "%f[%w_][%d%.]+%f[^%w_]", type = "number"   },
-    { pattern = "%..*:",                  type = "keyword2" },
-    { pattern = ".*:",                    type = "function" },
+    { pattern = "^%..*:%s",               type = "keyword2" },
+    { pattern = "^.*:%s",                 type = "function" },
   },
   symbols = {
   },


### PR DESCRIPTION
The pattern that matches the `target` syntax element in a Makefile over-matches strings like `GIT_URL = https://www.kernel.org/pub/software/scm/git/git-$(GIT_VER).tar.xz`:

<img width="483" height="132" alt="image" src="https://github.com/user-attachments/assets/6e28eadf-3b21-499b-a3d8-18c0ed91a503" />

I also fixed the pattern for the `special target` syntax (es. `.PHONY:`).