### PR TITLE
Add selectionexpand plugin

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2225,6 +2225,14 @@
       "version": "0.1"
     },
     {
+      "description": "Selection expansion known from other editors for Lite XL.",
+      "id": "selectionexpand",
+      "mod_version": "3",
+      "name": "Selection Expand",
+      "remote": "https://github.com/sp0rk/lite-xl-selectionexpand.git:01b77072d5e8da5d989ec0f090b83b5a66da88ae",
+      "version": "0.1.0"
+    },
+    {
       "description": "Highlights regions of code that match the current selection *([screenshot](https://user-images.githubusercontent.com/3920290/80710883-5f597c80-8ae7-11ea-97f0-76dfacc08439.png))*",
       "id": "selectionhighlight",
       "mod_version": "3",


### PR DESCRIPTION
Adds an external MIT-licensed Selection Expand plugin for selection expansion known from other editors.

The plugin is published at https://github.com/sp0rk/lite-xl-selectionexpand and the manifest pins version 0.1.0 to commit 01b77072d5e8da5d989ec0f090b83b5a66da88ae.

Validation:
- Parsed manifest.json with Python JSON parser
- Confirmed local LPM discovery of selectionexpand from this manifest
- Confirmed standalone repository main and v0.1.0 tag point to the pinned commit
- Confirmed LPM installs selectionexpand from the local manifest clone and published pinned remote