### PR TITLE
fix/gitopen-for-windows: Fix GitOpen Plugin Broken On Windows

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -588,7 +588,7 @@
       "id": "gitopen",
       "mod_version": "3",
       "path": "plugins/gitopen.lua",
-      "version": "0.1"
+      "version": "0.2"
     },
     {
       "description": "Displays git branch and insert/delete count in status bar *([screenshot](https://user-images.githubusercontent.com/3920290/81107223-bcea3080-8f0e-11ea-8fc7-d03173f42e33.png))*",

--- a/plugins/gitopen.lua
+++ b/plugins/gitopen.lua
@@ -2,6 +2,7 @@
 local core = require "core"
 local command = require "core.command"
 local common = require "core.common"
+local config = require "core.config"
 
 local function exec(cmd)
   local proc = process.start(cmd)

--- a/plugins/gitopen.lua
+++ b/plugins/gitopen.lua
@@ -2,7 +2,22 @@
 local core = require "core"
 local command = require "core.command"
 local common = require "core.common"
+local config = require "core.config"
 
+config.plugins.gitopen = common.merge({
+  normalize_paths = true,
+
+  config_spec = {
+    name = "Git Open",
+    {
+      label = "Normalize Paths",
+      description = "Normalize Git paths by converting '\\' to '/'.",
+      path = "normalize_paths",
+      type = "toggle",
+      default = true
+    }
+  }
+}, config.plugins.gitopen)
 
 local function exec(cmd)
   local proc = process.start(cmd)
@@ -15,6 +30,14 @@ local function exec(cmd)
   return proc:read_stdout() or ""
 end
 
+-- Git for Windows uses / as Unix based systems
+local function normalize_path(path)
+  if config.plugins.gitopen.normalize_paths then
+    return path:gsub('\\', '/')
+  end
+
+  return path
+end
 
 local function git_find_files_and_open(commit)
   local git_root = exec({"git", "rev-parse", "--show-toplevel"}):match( "^%s*(.-)%s*$" )
@@ -22,11 +45,11 @@ local function git_find_files_and_open(commit)
 
   local git_files = {}
   for str in string.gmatch(file_list_str, "([^\n]+)") do
-    git_files[git_root .. PATHSEP .. str] = true
+    git_files[normalize_path(git_root .. PATHSEP .. str)] = true
   end
 
   for dir, item in core.get_project_files() do
-    local key = dir .. PATHSEP .. item.filename
+    local key = normalize_path(dir .. PATHSEP .. item.filename)
     if git_files[key] then
       core.root_view:open_doc(core.open_doc(item.filename))
     end
@@ -51,3 +74,4 @@ command.add(nil, {
     })
   end,
 })
+

--- a/plugins/gitopen.lua
+++ b/plugins/gitopen.lua
@@ -15,19 +15,15 @@ local function exec(cmd)
 end
 
 local function git_find_files_and_open(commit)
-  local git_root = exec({"git", "rev-parse", "--show-toplevel"}):match( "^%s*(.-)%s*$" )
+  local git_root = exec({"git", "rev-parse", "--show-toplevel"}):match("^%s*(.-)%s*$")
   local file_list_str = exec({"git", "show", "--name-only", "--pretty=format:", commit})
 
-  local git_files = {}
   for str in string.gmatch(file_list_str, "([^\n]+)") do
     -- Nomalize path as Git for Windows uses / as Unix based systems
-    git_files[common.normalize_path(git_root .. PATHSEP .. str)] = true
-  end
+    local filename = common.normalize_path(git_root .. PATHSEP .. str)
 
-  for dir, item in core.get_project_files() do
-    local key = common.normalize_path(dir .. PATHSEP .. item.filename)
-    if git_files[key] then
-      core.root_view:open_doc(core.open_doc(item.filename))
+    if not common.match_pattern(common.basename(filename), config.ignore_files) then
+      core.root_view:open_doc(core.open_doc(filename))
     end
   end
 end

--- a/plugins/gitopen.lua
+++ b/plugins/gitopen.lua
@@ -2,22 +2,6 @@
 local core = require "core"
 local command = require "core.command"
 local common = require "core.common"
-local config = require "core.config"
-
-config.plugins.gitopen = common.merge({
-  normalize_paths = true,
-
-  config_spec = {
-    name = "Git Open",
-    {
-      label = "Normalize Paths",
-      description = "Normalize Git paths by converting '\\' to '/'.",
-      path = "normalize_paths",
-      type = "toggle",
-      default = true
-    }
-  }
-}, config.plugins.gitopen)
 
 local function exec(cmd)
   local proc = process.start(cmd)
@@ -30,26 +14,18 @@ local function exec(cmd)
   return proc:read_stdout() or ""
 end
 
--- Git for Windows uses / as Unix based systems
-local function normalize_path(path)
-  if config.plugins.gitopen.normalize_paths then
-    return path:gsub('\\', '/')
-  end
-
-  return path
-end
-
 local function git_find_files_and_open(commit)
   local git_root = exec({"git", "rev-parse", "--show-toplevel"}):match( "^%s*(.-)%s*$" )
   local file_list_str = exec({"git", "show", "--name-only", "--pretty=format:", commit})
 
   local git_files = {}
   for str in string.gmatch(file_list_str, "([^\n]+)") do
-    git_files[normalize_path(git_root .. PATHSEP .. str)] = true
+    -- Nomalize path as Git for Windows uses / as Unix based systems
+    git_files[common.normalize_path(git_root .. PATHSEP .. str)] = true
   end
 
   for dir, item in core.get_project_files() do
-    local key = normalize_path(dir .. PATHSEP .. item.filename)
+    local key = common.normalize_path(dir .. PATHSEP .. item.filename)
     if git_files[key] then
       core.root_view:open_doc(core.open_doc(item.filename))
     end

--- a/plugins/gitopen.lua
+++ b/plugins/gitopen.lua
@@ -23,6 +23,7 @@ local function git_find_files_and_open(commit)
     -- Nomalize path as Git for Windows uses / as Unix based systems
     local filename = common.normalize_path(git_root .. PATHSEP .. str)
 
+    -- Only open files within the commit whose names do not match the configured ignore file patterns
     if not common.match_pattern(common.basename(filename), config.ignore_files) then
       core.root_view:open_doc(core.open_doc(filename))
     end


### PR DESCRIPTION
The `gitopen` plugin does not work on Windows, as Git for Windows returns path using `/` just as Unix based systems, instead of the typical `\` used for Windows paths. 

When then invoking command `Gitopen: Open From Commit`, since `PATHSEP` goes by system and when using Windows, the constructed path returned, for example `C:/user/project/src\main.c`, will be invalid and nothing happens. 

A normalize function for the path makes sure the path uses `/` no matter the system. Also added a toggle to enable/disable normalizing in `gitopen` plugin settings just in case.